### PR TITLE
fix(tests): unignore SPEC-201 SQL injection test — passes cleanly

### DIFF
--- a/server/tests/security.rs
+++ b/server/tests/security.rs
@@ -26,7 +26,6 @@ async fn wrong_method_returns_405() {
 
 // SPEC-201: SQL injection in login credential is safely handled
 #[tokio::test]
-#[ignore = "not yet implemented"]
 async fn sql_injection_in_credential_is_safe() {
     let server = helpers::test_server().await;
     let res = server


### PR DESCRIPTION
## Summary
- Removes `#[ignore = "not yet implemented"]` from `sql_injection_in_credential_is_safe` in `server/tests/security.rs`
- The test passes: credential is SHA-256 hashed before any DB interaction, and SQLx uses parameterized queries — SQL injection is structurally impossible

## Why it was ignored
The test was marked "not yet implemented" but the protection was already in place (parameterized queries + credential hashing). It just hadn't been verified.

## Closes
Closes #19

## Test plan
- [x] `cargo test --test security sql_injection` passes locally
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)