### PR TITLE
feat(tests): SPEC-004 + SPEC-006 — expired token + rate limit tests

### DIFF
--- a/server/src/error.rs
+++ b/server/src/error.rs
@@ -45,7 +45,7 @@ impl IntoResponse for AppError {
     fn into_response(self) -> Response {
         let (status, code) = match &self {
             AppError::NotFound => (StatusCode::NOT_FOUND, "not_found"),
-            AppError::Unauthorized(_) => (StatusCode::UNAUTHORIZED, "invalid_token"),
+            AppError::Unauthorized(code) => (StatusCode::UNAUTHORIZED, *code),
             AppError::Forbidden => (StatusCode::FORBIDDEN, "forbidden"),
             AppError::BadRequest(_) => (StatusCode::BAD_REQUEST, "bad_request"),
             AppError::RateLimited => (StatusCode::TOO_MANY_REQUESTS, "rate_limited"),

--- a/server/tests/auth.rs
+++ b/server/tests/auth.rs
@@ -2,6 +2,8 @@ mod helpers;
 use axum::http::StatusCode;
 use serde_json::json;
 
+const TEST_SECRET: &str = "test-secret-minimum-32-characters!!";
+
 // SPEC-001: new user → 201
 #[tokio::test]
 async fn login_new_user_returns_201() {
@@ -77,4 +79,61 @@ async fn no_private_key_in_auth_response() {
         !re.is_match(&body),
         "private key pattern found in response: {body}"
     );
+}
+
+// SPEC-004: expired token → 401 with error "token_expired"
+#[tokio::test]
+async fn expired_token_returns_401() {
+    let server = helpers::test_server().await;
+
+    // Craft a JWT signed with the test secret but with exp in the past.
+    // Use the concrete Claims struct so jsonwebtoken validates exp correctly.
+    let expired_claims = ghostkey::auth_jwt::Claims {
+        sub: "00000000-0000-0000-0000-000000000001".to_string(),
+        exp: 1_000_000, // 1970-01-12 — definitely expired
+        iat: 999_999,
+    };
+    let token = jsonwebtoken::encode(
+        &jsonwebtoken::Header::default(),
+        &expired_claims,
+        &jsonwebtoken::EncodingKey::from_secret(TEST_SECRET.as_bytes()),
+    )
+    .unwrap();
+
+    let res = server
+        .post("/auth/refresh")
+        .json(&json!({ "token": token }))
+        .await;
+
+    res.assert_status(StatusCode::UNAUTHORIZED);
+    assert_eq!(res.json::<serde_json::Value>()["error"], "token_expired");
+}
+
+// SPEC-006: rate limit — 11th login from same IP returns 429
+#[tokio::test]
+async fn login_rate_limit_returns_429() {
+    let server = helpers::test_server().await;
+
+    // Rate limit is 10 req / 60s per IP key.
+    // All requests hit "login:unknown" (no x-forwarded-for in test).
+    for i in 0..10 {
+        let res = server
+            .post("/auth/login")
+            .json(&json!({
+                "method": "email",
+                "credential": format!("ratelimit{i}@example.com"),
+            }))
+            .await;
+        // First 10 must succeed (201 new user each time)
+        res.assert_status(StatusCode::CREATED);
+    }
+
+    // 11th request — same "unknown" IP bucket, now exhausted
+    let res = server
+        .post("/auth/login")
+        .json(&json!({ "method": "email", "credential": "overflow@example.com" }))
+        .await;
+
+    res.assert_status(StatusCode::TOO_MANY_REQUESTS);
+    assert_eq!(res.json::<serde_json::Value>()["error"], "rate_limited");
 }


### PR DESCRIPTION
## Summary
- Adds SPEC-004 test: expired JWT → 401 `"token_expired"`
- Adds SPEC-006 test: 11th login from same IP → 429 `"rate_limited"`
- Bug fix: `AppError::Unauthorized` was always serializing as `"invalid_token"` — fixed `IntoResponse` to propagate the inner error code string (so `"token_expired"` is now returned correctly for expired signatures)

## Details

**SPEC-004** crafts a valid JWT with `exp` set to 1970, signed with the test secret, then calls `/auth/refresh`. The `auth_jwt::validate` function correctly identifies `ExpiredSignature` and returns `Unauthorized("token_expired")` — but `error.rs` was discarding that code and always emitting `"invalid_token"`. Fixed.

**SPEC-006** exhausts the rate limiter (10 req / 60s per IP, keyed by `x-forwarded-for` or `"unknown"` in tests) with 10 logins, then verifies the 11th returns 429.

## Files changed
- `server/tests/auth.rs` — 2 new tests + `const TEST_SECRET`
- `server/src/error.rs` — `Unauthorized(_)` → `Unauthorized(code)` in IntoResponse

## Closes
Closes #18

## Test plan
- [x] All 7 auth tests pass locally
- [x] Full `cargo test` passes (27 Rust tests, 1 ignored)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)