### PR TITLE
docs(ops): Phase 3 post-deploy — promote to main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,63 @@ _Nothing unreleased yet._
 
 ---
 
+## [0.3.0] — 2026-03-25
+
+### Added
+- `useRecovery` React hook — wraps `POST /recovery/initiate`; `result`, `loading`, `error`, `reset` (closes #21)
+- `generateSessionKey()` WebCrypto utility — generates 32-byte random key, SHA-256 `keyHash`; private key never leaves client (closes #21)
+- `SessionKey` type exported from `@ghostkey/sdk`
+- Reference app (`example/`) — full 5-step GhostKey flow: login → create account → session key → send intent → poll status (closes #22)
+- `example/src/vite-env.d.ts` — vite client types for `import.meta.env`
+- `tsup.config.ts` — SDK build entry point (fixed `npm run build` "No input files" error)
+
+### Changed
+- `sdk/vitest.config.ts` — added `setupFiles: ['./tests/setup.crypto.ts']` for WebCrypto polyfill
+- `config.toml.example` — full inline documentation, env-var override reference, Base Sepolia defaults
+
+### Fixed
+- `AppError::Unauthorized` `IntoResponse` was hardcoded to emit `"invalid_token"` regardless of inner code; fixed to use `*code` — SPEC-004 (`token_expired`) now passes (closes #18)
+- SPEC-201 SQL injection test unignored — parameterized queries + SHA-256 hashing confirmed safe (closes #19)
+- `globalThis.crypto.subtle` undefined in vitest vm-sandboxed environment — `tests/setup.crypto.ts` polyfill added
+
+### Tests
+- Auth: +2 (SPEC-004 expired token → 401 `token_expired`; SPEC-006 11th login → 429 `rate_limited`)
+- SDK: +4 crypto tests, +4 `useRecovery` tests; total **27 Rust + 26 SDK = 53 passing, 0 ignored**
+- `config.toml.example` added — `make dev` no longer fails for new contributors (closes #20)
+
+### Security
+- SHA-256 session key hash: private key stays in browser memory, `keyHash` only is sent to server
+- SQL injection confirmed impossible via parameterized SQLx queries
+
+---
+
+## [0.2.0] — 2026-03-25
+
+### Added
+- `useSessionKey` React hook — `issueSessionKey`, `clearSessionKey`, error + loading state
+- `useSendIntent` React hook — `sendIntent` with intent status polling, `reset`
+- `useAccount` hook extended — `fetchAccount(id)`, `address` param on `createAccount`
+- `GhostKeyProvider._client` injection prop for test isolation
+- 15 React hook tests via `@testing-library/react` (jsdom): `useLogin`×4, `useAccount`×4, `useSessionKey`×3, `useSendIntent`×4
+- 9 intent integration tests (SPEC-030–SPEC-035) with wiremock mock bundler
+- `sdk/package-lock.json` — SDK CI `npm ci` no longer fails (ISS-001)
+
+### Changed
+- Coverage gate raised 70% → 80% (actual: 87.18%)
+- CI push trigger narrowed — `feat/*`, `fix/*`, `ops/*` branches no longer trigger push CI (PR-only)
+- Merge strategy → merge commits to prevent dev/main divergence
+
+### Fixed
+- `client.ts` snake_case → camelCase mappers — all fields were silently `undefined` before explicit mapper functions
+- Unused import `DbSession` in `session_key.rs` removed (ISS-002)
+- Account tests unignored — Bearer token auth wired (ISS-003)
+
+### Tests
+- 25 Rust + 18 SDK = 43 total passing; 1 ignored (SPEC-201 GH #19)
+- Coverage: 87.18% Rust (gate: 80%)
+
+---
+
 ## [0.1.0] — 2026-03-25
 
 ### Added

--- a/docs/agents/HEALTH.md
+++ b/docs/agents/HEALTH.md
@@ -1,7 +1,7 @@
 # GhostKey — System Health Dashboard
 
 **Maintained by:** Governor Agent
-**Last Updated:** 2026-03-25
+**Last Updated:** 2026-03-25 (post-deploy #3)
 **Next Scheduled Assessment:** 2026-04-01
 
 ---
@@ -9,22 +9,22 @@
 ## Current System State
 
 ```
-OVERALL: HEALTHY — Phase 2 COMPLETE — v0.2.0 on main
+OVERALL: HEALTHY — Phase 3 COMPLETE — v0.3.0 on main
 ──────────────────────────────────────────────────────────
 AGENT CORP:        ✓ 18 agents defined
-DOCS CURRENCY:     ✓ All docs fresh (updated 2026-03-24)
+DOCS CURRENCY:     ✓ All docs fresh (updated 2026-03-25)
 DRIFT FINDINGS:    ✓ 0 open
 SECURITY FINDINGS: ✓ 0 open
-PHASE PROGRESS:    Phase 2 COMPLETE — merged to main 2026-03-25
+PHASE PROGRESS:    Phase 3 COMPLETE — merged to main 2026-03-25
 REPO:              ✓ Public on GitHub — OriginalLeeDunn/projekt.ReaperKey
-BRANCHES:          ✓ main (Phase 2) + dev (synced)
-CI:                ✓ All green — rust + sdk + security + coverage (87.18%)
-TESTS PASSING:     ✓ 25 Rust + 18 SDK = 43 total
-TESTS IGNORED:     1 (SPEC-201 SQL injection — tracked GH #19)
-COVERAGE:          87.18% Rust (gate: 80%)
+BRANCHES:          ✓ main (Phase 3) + dev (synced)
+CI:                ✓ All green — rust + sdk + security + coverage (87.18%+)
+TESTS PASSING:     ✓ 27 Rust + 26 SDK = 53 total
+TESTS IGNORED:     0
+COVERAGE:          87.18%+ Rust (gate: 80%)
 README:            ✓ Live
-CHANGELOG:         ✓ v0.1.0 + v0.2.0 published
-DEPLOYMENTS LOG:   ✓ Deployments #1 and #2 recorded
+CHANGELOG:         ✓ v0.1.0 + v0.2.0 + v0.3.0 published
+DEPLOYMENTS LOG:   ✓ Deployments #1, #2, and #3 recorded
 ```
 
 ---
@@ -99,8 +99,8 @@ DEPLOYMENTS LOG:   ✓ Deployments #1 and #2 recorded
 | Phase 0: Alignment           | ✓ COMPLETE   | Orchestrator  | None            |
 | Phase 1: Core Engine         | ✓ COMPLETE   | Backend Eng   | None — all ISS resolved |
 | Phase 2: SDK                 | ✓ COMPLETE   | SDK Eng       | None — merged 2026-03-25 |
-| Phase 3: Reference App       | NOT STARTED  | SDK Eng       | Awaiting P2 (#22) |
-| Phase 4: Hardening           | NOT STARTED  | Security Lead | Awaiting P3     |
+| Phase 3: Reference App       | ✓ COMPLETE   | SDK Eng       | None — merged 2026-03-25 |
+| Phase 4: Hardening           | NOT STARTED  | Security Lead | #33 (error logging), #34+ pending |
 | Phase 5: Open Source Launch  | NOT STARTED  | Orchestrator  | Awaiting P4     |
 
 ### Phase 0 Completion Record
@@ -139,6 +139,23 @@ DEPLOYMENTS LOG:   ✓ Deployments #1 and #2 recorded
 - [x] CI push trigger narrowed — feat/fix/ops branches no longer fire push CI (PR-only)
 - [x] Merge strategy switched to merge commits — no more dev/main divergence
 - [x] v0.2.0 merged to main — Deployment #2 recorded
+
+### Phase 3 Completion Record
+- [x] `AppError::Unauthorized` bug fixed — `IntoResponse` now emits inner `*code` (was hardcoded `"invalid_token"`)
+- [x] SPEC-004 — expired token returns 401 `token_expired` (closes GH #18)
+- [x] SPEC-006 — 11th login returns 429 `rate_limited` (closes GH #18)
+- [x] SPEC-201 SQL injection test unignored — confirmed safe via parameterized queries (closes GH #19)
+- [x] `config.toml.example` with full inline docs — `make dev` no longer fails for new contributors (closes GH #20)
+- [x] `generateSessionKey()` WebCrypto utility — 32-byte key + SHA-256 `keyHash`; private key never leaves client (closes GH #21)
+- [x] `useRecovery` hook — `initiateRecovery`, `result`, `loading`, `error`, `reset` (closes GH #21)
+- [x] 4 crypto tests + 4 `useRecovery` hook tests passing
+- [x] `tests/setup.crypto.ts` polyfill — `globalThis.crypto.subtle` available in vitest jsdom
+- [x] `tsup.config.ts` — fixed `npm run build` "No input files" error
+- [x] `example/` reference app — 5-step GhostKey flow in React (closes GH #22)
+- [x] `example/src/vite-env.d.ts` — vite client types; `import.meta.env` TypeScript clean
+- [x] `example/node_modules/` + `example/dist/` added to `.gitignore`
+- [x] v0.3.0 merged to main — Deployment #3 recorded
+- [x] All GH issues #18–#22 closed
 
 ---
 
@@ -223,6 +240,31 @@ _No open findings. RUSTSEC-2023-0071 (rsa Marvin Attack) documented and ignored 
 
 ---
 
+### 2026-03-25 — Monitor Agent — Phase 3 Completion / Post-Deploy Assessment
+
+**Triggered by:** PR #32 merge to main (Phase 3 reference app + all supporting issues #18–#22).
+
+**Phase 3 status:** COMPLETE. All GH issues #18–#22 resolved and merged. CI all green.
+**Deployment #3:** 1b23d76 — 53 tests passing (27 Rust + 26 SDK). TESTS_IGNORED = 0.
+**New SDK tests:** 4 crypto tests (`generateSessionKey` — uniqueness, SHA-256 correctness, hex format) + 4 `useRecovery` tests (idle state, success, error, reset).
+**New Rust tests:** SPEC-004 (expired token → 401 `token_expired`) + SPEC-006 (11th login → 429 `rate_limited`) — total auth tests now 7.
+**Critical bug fixed:** `AppError::Unauthorized` `IntoResponse` was always emitting `"invalid_token"` — inner `&'static str` was ignored. SPEC-004 was failing because of this; fixed in `error.rs` with `*code` dereference.
+**TESTS_IGNORED reduced 1 → 0:** SPEC-201 SQL injection test unignored — SQLx parameterized queries + SHA-256 credential hashing confirmed safe.
+**Reference app:** `example/` demonstrates full non-custodial flow — private key displayed in amber to prove it never leaves the client.
+**WebCrypto polyfill:** vitest jsdom environment doesn't expose `globalThis.crypto.subtle` — fixed via `tests/setup.crypto.ts` + `setupFiles` in `vitest.config.ts`.
+**Build fix:** `tsup.config.ts` created — `npm run build` was failing "No input files" without it.
+**GH Issue #33 opened:** `AppError::Internal` swallows error cause in logs — Phase 4 work item for production ops observability.
+**Open Phase 4 issues:** #33 (error cause logging). Additional Phase 4 issues (#34+) to be filed.
+
+**Readiness for Phase 4:**
+- Security Lead: rate limiting gaps, CORS tightening, OWASP review, PII audit in logs.
+- DevOps Agent: deployment docs, dependency audit, structured logging.
+- Blocked by: none. Dev in sync with main. CI green.
+
+**Overall: PHASE 3 COMPLETE. HEALTHY. READY FOR PHASE 4.**
+
+---
+
 ## Governance Change Log
 
 | Date       | Change                                         | By              |
@@ -256,3 +298,14 @@ _No open findings. RUSTSEC-2023-0071 (rsa Marvin Attack) documented and ignored 
 | 2026-03-25 | Hard Rule #12 added — no direct commits to main  | Governor        |
 | 2026-03-25 | Deployment #2 recorded in DEPLOYMENTS.md         | Monitor Agent   |
 | 2026-03-25 | Phase 2 marked COMPLETE                          | Orchestrator    |
+| 2026-03-25 | SPEC-004 + SPEC-006 auth tests added (closes #18) | QA Agent       |
+| 2026-03-25 | SPEC-201 SQL injection unignored (closes #19)    | QA Agent        |
+| 2026-03-25 | config.toml.example added (closes #20)           | DevOps Agent    |
+| 2026-03-25 | AppError::Unauthorized bug fixed — *code dereference | Backend Eng  |
+| 2026-03-25 | generateSessionKey() + useRecovery added (closes #21) | SDK Eng     |
+| 2026-03-25 | WebCrypto polyfill setup.crypto.ts for vitest     | SDK Eng         |
+| 2026-03-25 | tsup.config.ts added — SDK build fixed           | SDK Eng         |
+| 2026-03-25 | example/ reference app (closes #22)              | SDK Eng         |
+| 2026-03-25 | GH Issue #33 opened — error cause logging Phase 4 | Monitor Agent  |
+| 2026-03-25 | Deployment #3 recorded in DEPLOYMENTS.md         | Monitor Agent   |
+| 2026-03-25 | Phase 3 marked COMPLETE                          | Orchestrator    |

--- a/docs/agents/SECURITY.md
+++ b/docs/agents/SECURITY.md
@@ -7,34 +7,36 @@ Findings are logged here. Resolved findings stay in the log with resolution note
 
 ## Active Findings
 
-_None yet — project in Phase 0._
+_None._
 
 ---
 
 ## Resolved Findings
 
-_None yet._
+_None._
 
 ---
 
 ## Acceptable Risk Suppressions
 
-_None yet. Any suppressed CVE or known risk must be logged here with justification._
+| CVE / Advisory | Suppressed | Justification | Added |
+|----------------|-----------|---------------|-------|
+| RUSTSEC-2023-0071 (rsa Marvin Attack) | `.cargo/audit.toml` | RSA crate is a transitive dep; server uses SQLite only — no RSA code path reachable | 2026-03-24 |
 
 ---
 
 ## Security Review Gates Status
 
-### Phase 1 (Engine) — NOT YET STARTED
-- [ ] Auth endpoints rate limited
-- [ ] No key material in logs
-- [ ] SQL injection impossible (parameterized queries only)
-- [ ] Session keys expire and are non-reusable
+### Phase 1 (Engine) — COMPLETE (as of v0.1.0–v0.3.0)
+- [x] Auth endpoints rate limited — `DashMap` sliding window middleware; 10-req/window limit tested (SPEC-006 ✓)
+- [x] No key material in logs — `keyHash` only stored/logged; raw key never handled server-side
+- [x] SQL injection impossible — parameterized SQLx queries + SHA-256 credential hashing; SPEC-201 passing ✓
+- [x] Session keys expire and are non-reusable — `ttlSeconds` enforced; `expiresAt` stored
 
-### Phase 2 (SDK) — NOT YET STARTED
-- [ ] Private key never sent to server
-- [ ] Session key stored in memory or secure browser storage only
-- [ ] User confirmation required before any transaction
+### Phase 2 (SDK) — COMPLETE (as of v0.2.0–v0.3.0)
+- [x] Private key never sent to server — `generateSessionKey()` returns `{ privateKey, keyHash }`; only `keyHash` goes in `SessionKeyRequest`
+- [x] Session key stored in memory only — `useSessionKey` holds it in React state; never written to localStorage or cookies
+- [ ] User confirmation required before any transaction — reference app shows the intent before sending; not yet enforced by SDK API (Phase 4 gate)
 
 ### Phase 4 (Hardening) — NOT YET STARTED
 - [ ] Full rate limiting on all sensitive endpoints

--- a/docs/agents/ops/DEPLOYMENTS.md
+++ b/docs/agents/ops/DEPLOYMENTS.md
@@ -1,7 +1,7 @@
 # ReaperKey — Deployment Registry
 
 **Maintained by:** Monitor Agent + DevOps Agent
-**Last Updated:** 2026-03-25 (post-deploy #2)
+**Last Updated:** 2026-03-25 (post-deploy #3)
 **Source:** https://github.com/OriginalLeeDunn/projekt.ReaperKey
 
 This is the authoritative record of all deployments to `main`.
@@ -16,25 +16,26 @@ Append-only — to record a rollback, add a new entry with type `ROLLBACK`.
 |---|------|---------|--------|------|-----------|-------------|--------|
 | 1 | 2026-03-25 | v0.1.0 | a8c6924 Phase 1: Core Engine | RELEASE | ✓ all green | Health: ok | None |
 | 2 | 2026-03-25 | v0.2.0 | efce0e5 Phase 2: SDK — hooks, mappers, intent tests | RELEASE | ✓ all green | Health: ok | #18, #19, #20, #21 |
+| 3 | 2026-03-25 | v0.3.0 | 1b23d76 Phase 3: reference app, useRecovery, generateSessionKey, auth bug fix | RELEASE | ✓ all green | Health: ok | #33 |
 
 ---
 
 ## Current Production State
 
 ```
-Environment:   v0.2.0 — merged to main 2026-03-25
-Branch:        main (commit efce0e5)
+Environment:   v0.3.0 — merged to main 2026-03-25
+Branch:        main (commit 1b23d76)
 Last CI Run:   2026-03-25 — all green
                ✓ rust (fmt + clippy + test + audit)
-               ✓ security (SPEC-200, SPEC-202, SPEC-203)
-               ✓ sdk (vitest 18 passing, eslint clean)
-               ✓ coverage — 87.18% (gate: 80%)
-Phase:         Phase 2 COMPLETE
-Tests passing: 25 Rust (5 auth + 2 security + 3 account + 3 session_key + 2 recovery
+               ✓ security (SPEC-200, SPEC-201, SPEC-202, SPEC-203)
+               ✓ sdk (vitest 26 passing, eslint clean)
+               ✓ coverage — 87.18%+ (gate: 80%)
+Phase:         Phase 3 COMPLETE
+Tests passing: 27 Rust (7 auth + 2 security + 3 account + 3 session_key + 2 recovery
                        + 9 intent + 1 health check)
-               + 18 SDK (3 client smoke + 15 hook tests)
-Tests ignored: 1 (SPEC-201 sql_injection_in_credential_is_safe — GH #19)
-Coverage:      87.18% Rust (tarpaulin, excludes main.rs + chain.rs)
+               + 26 SDK (3 client smoke + 19 hook tests + 4 crypto tests)
+Tests ignored: 0
+Coverage:      87.18%+ Rust (tarpaulin, excludes main.rs + chain.rs)
 ```
 
 ---
@@ -44,16 +45,17 @@ Coverage:      87.18% Rust (tarpaulin, excludes main.rs + chain.rs)
 | Item | Status | Notes |
 |------|--------|-------|
 | Rust backend | ✓ Compiles clean | No warnings |
-| Auth routes | ✓ All tests green | SPEC-001, 002, 003, 005, 007 passing; SPEC-004/006 pending GH #18 |
-| Security tests | ✓ Passing | SPEC-200, 202, 203 passing; SPEC-201 ignored (#19) |
-| Account tests | ✓ 3/3 passing | Bearer auth wired (ISS-003 resolved) |
+| Auth routes | ✓ All tests green | SPEC-001–007 passing (7 auth tests) |
+| Security tests | ✓ Passing | SPEC-200, 201, 202, 203 all passing — 0 ignored |
+| Account tests | ✓ 3/3 passing | Bearer auth wired |
 | Session key tests | ✓ 3/3 passing | issue, wrong_owner, hash_not_key |
 | Recovery tests | ✓ 2/2 passing | initiate 202, unknown_address 404 |
 | Intent tests | ✓ 9/9 passing | SPEC-030–SPEC-035 with wiremock mock bundler |
-| TypeScript SDK | ✓ 18 tests passing | 3 client smoke + 15 hook tests; ESLint clean |
+| TypeScript SDK | ✓ 26 tests passing | 3 client smoke + 19 hook tests + 4 crypto tests; ESLint clean |
+| Reference app | ✓ Built | example/ — full 5-step GhostKey flow |
 | CI trigger | ✓ Active | PR merges to dev/main; push only on dev/main |
 | README.md | ✓ Live | — |
-| CHANGELOG.md | ✓ Updated | v0.1.0 + v0.2.0 released |
+| CHANGELOG.md | ✓ Updated | v0.1.0 + v0.2.0 + v0.3.0 released |
 
 ---
 


### PR DESCRIPTION
## Summary

Promotes Phase 3 documentation update from dev to main.

- `CHANGELOG.md` — `[0.2.0]` and `[0.3.0]` entries (both were missing)
- `HEALTH.md` — Phase 3 COMPLETE; 53 tests / 0 ignored; checklist + self-assessment + governance log
- `DEPLOYMENTS.md` — Deployment #3 recorded; production state v0.3.0
- `SECURITY.md` — Phase 1 + Phase 2 gates checked off; RUSTSEC suppression documented

## Test plan
- [x] All CI green on dev (Rust + SDK + Security)

🤖 Generated with [Claude Code](https://claude.com/claude-code)