### PR TITLE
docs: fix SPEC-040 /recovery/initiate path + phase completion workflow

### DIFF
--- a/docs/agents/GOVERNANCE.md
+++ b/docs/agents/GOVERNANCE.md
@@ -71,6 +71,9 @@ This table defines when each agent must act. All agents must read this.
 | New npm dependency added               | Dep Scanner, SDK Engineer                     | Run npm audit, log if crypto-adjacent |
 | New chain supported                    | Architect, Backend Eng, Docs Agent            | Update STACK.md, config schema, docs  |
 | Phase N completed                      | Orchestrator, Audit Lead, Docs Agent          | Update DECISIONS.md, roadmap.md       |
+| Phase N merged to main                 | DevOps Agent, QA Agent                        | Run validation pass per phase; file issues for all gaps |
+| All phase validation gaps resolved     | DevOps Agent, Monitor Agent, Docs Agent       | Post-deploy docs branch (CHANGELOG + HEALTH + DEPLOYMENTS), git tag, GitHub release |
+| Phase N+1 gate check                   | Orchestrator, Governor                        | Confirm: 0 open issues (except N+1 scope), tag + release published, all docs current |
 | Security finding opened                | Security Lead, Audit Lead                     | Log in SECURITY.md, DECISIONS.md      |
 | Security finding resolved              | Security Lead, Audit Lead                     | Update SECURITY.md with resolution    |
 | Contract code changed                  | Contract Auditor, Security Lead               | Audit required before merge           |

--- a/docs/agents/TEST_SPECS.md
+++ b/docs/agents/TEST_SPECS.md
@@ -262,7 +262,7 @@ OWNER:  server/tests/intent.rs
 ### SPEC-040: Initiate Recovery Flow
 ```
 GIVEN:  user cannot authenticate (lost credentials)
-WHEN:   POST /recovery/init { account_address: "0x..." }
+WHEN:   POST /recovery/initiate { account_address: "0x..." }
 THEN:   - HTTP 202
         - response contains { recovery_id, method, instructions }
         - recovery record created with status "initiated"

--- a/docs/agents/ops/DEVOPS.md
+++ b/docs/agents/ops/DEVOPS.md
@@ -78,6 +78,113 @@ Gate: PR to main is blocked until all jobs above are green.
 
 ---
 
+## Phase Completion Workflow
+
+Every time a phase merges to main, the following must happen **before** Phase N+1 begins:
+
+### Step 1 — Validation Pass
+Run a validation agent per phase to check code against specs:
+```
+For each completed phase:
+  - Read all SPEC-XXX tests for that phase
+  - Read the actual implementation files
+  - Compare: any spec not tested? Any test not passing? Any API mismatch?
+  - File a GitHub issue for each gap found (label: agent-fix, qa)
+```
+Gate: **All validation gaps must be filed as issues and resolved before proceeding.**
+
+### Step 2 — Fix Issues
+For each issue filed:
+1. Create `fix/<slug>` branch off `dev`
+2. Fix, commit with `closes #N` in message
+3. PR → dev → CI green → merge
+4. Repeat until zero open issues (except Phase N+1 scope items)
+
+### Step 3 — Post-Deploy Documentation
+After all fixes are merged to main, create a documentation update:
+
+```bash
+# 1. Create ops branch off dev
+git checkout dev && git pull
+git checkout -b ops/vX.Y.Z-post-deploy
+
+# 2. Update these files:
+#    - CHANGELOG.md         → add [X.Y.Z] section with all changes
+#    - docs/agents/HEALTH.md     → update system state block, test counts, open issues
+#    - docs/agents/ops/DEPLOYMENTS.md → append registry row + update production state
+
+# 3. Commit, push, open PR → dev
+git add CHANGELOG.md docs/agents/HEALTH.md docs/agents/ops/DEPLOYMENTS.md
+git commit -m "docs(ops): vX.Y.Z post-deploy — update HEALTH, DEPLOYMENTS, CHANGELOG"
+git push -u origin ops/vX.Y.Z-post-deploy
+gh pr create --base dev --title "docs(ops): vX.Y.Z post-deploy documentation update"
+
+# 4. CI green → merge to dev → open PR dev → main → CI green → merge
+```
+
+### Step 4 — Git Tags + GitHub Releases
+
+After the docs PR merges to main:
+
+```bash
+# Tag against the correct commit (use merge commit SHA from main)
+git tag vX.Y.Z <commit-sha>
+git push origin vX.Y.Z
+
+# Create GitHub release
+gh release create vX.Y.Z \
+  --title "vX.Y.Z — Phase N: <short description>" \
+  --notes "$(cat <<'EOF'
+## What's new
+<paste CHANGELOG section>
+
+## Test coverage
+- N Rust tests + N SDK tests = N total
+- Coverage: N% Rust | N% SDK
+EOF
+)"
+```
+
+**Important:** `gh release create` uses the tag name as the positional argument — do NOT use `--target <SHA>` (GitHub rejects short SHAs for that flag; use the tag itself).
+
+### Step 5 — Issue Cleanup
+
+GitHub only auto-closes issues via "closes #N" in commit messages when merged to the default branch directly. If any issues don't auto-close:
+
+```bash
+# Manually close with a resolution comment
+gh issue close <N> --comment "Resolved in vX.Y.Z (commit <SHA>). <one-line description of fix>."
+```
+
+Check after every PR merge to main:
+```bash
+gh issue list --state open
+# Should only show Phase N+1 scope items
+```
+
+---
+
+## Validation Protocol (Before Phase N+1)
+
+This is a required gate. Phase N+1 does not start until:
+
+- [ ] All Phase N specs have a passing test
+- [ ] All validation gap issues are CLOSED
+- [ ] `CHANGELOG.md` has a `[vX.Y.Z]` entry
+- [ ] `HEALTH.md` system state block reflects current test counts + coverage
+- [ ] `DEPLOYMENTS.md` has the new deployment row
+- [ ] Git tag `vX.Y.Z` exists and GitHub release is published
+- [ ] Zero open issues except Phase N+1 scope
+
+Run this check:
+```bash
+gh issue list --state open          # should be Phase N+1 scope only
+gh release list --limit 5           # vX.Y.Z should appear
+git tag --list | sort -V | tail -5  # tag should exist
+```
+
+---
+
 ## Local Dev Setup Target
 
 ```bash

--- a/server/src/routes/recovery.rs
+++ b/server/src/routes/recovery.rs
@@ -13,7 +13,7 @@ pub struct RecoveryInitRequest {
     pub account_address: String,
 }
 
-/// POST /recovery/init — SPEC-040
+/// POST /recovery/initiate — SPEC-040
 /// Initiates recovery for an account. Does NOT grant server key access.
 #[tracing::instrument(skip(state, body))]
 pub async fn init(


### PR DESCRIPTION
## Summary
- Fixes stale SPEC-040 spec (`/recovery/init` → `/recovery/initiate`) to match actual implementation
- Fixes stale doc comment in `server/src/routes/recovery.rs`
- Adds Phase Completion Workflow to DEVOPS.md (validation pass, fix cycle, post-deploy docs branch, git tags, GitHub releases, issue cleanup)
- Adds validation trigger rows to GOVERNANCE.md event table

## Root cause
Phase 3 validation agent flagged `/recovery/init` in TEST_SPECS.md — server and SDK were both correct at `/recovery/initiate`, only the spec doc and handler doc comment were stale.

## Checklist
- [x] No logic changes — docs and comment only
- [x] cargo fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)