### PR TITLE
fix: Phase 1 validation gaps — SPEC-035/033/021/023/203

### DIFF
--- a/docs/agents/TEST_SPECS.md
+++ b/docs/agents/TEST_SPECS.md
@@ -248,10 +248,11 @@ OWNER:  server/tests/intent.rs
 
 ### SPEC-035: Intent Rate Limiting
 ```
-GIVEN:  same account submits 20 intents within 60 seconds
-WHEN:   21st intent submission
+GIVEN:  same account submits 10 intents within 60 seconds (limit: 10/60s per user)
+WHEN:   11th intent submission
 THEN:   - HTTP 429
-        - Retry-After header present
+        - body: { error: "rate_limited" }
+        - Retry-After: 60 header present
 OWNER:  server/tests/intent.rs
 ```
 

--- a/server/migrations/0002_intent_reason.sql
+++ b/server/migrations/0002_intent_reason.sql
@@ -1,0 +1,2 @@
+-- Add reason field to intents for SPEC-033 (failed intent reason)
+ALTER TABLE intents ADD COLUMN reason TEXT;

--- a/server/src/models/intent.rs
+++ b/server/src/models/intent.rs
@@ -13,6 +13,7 @@ pub struct DbIntent {
     pub status: String,
     pub tx_hash: Option<String>,
     pub block_number: Option<i64>,
+    pub reason: Option<String>,
     pub created_at: i64,
     pub updated_at: i64,
 }
@@ -24,6 +25,7 @@ impl DbIntent {
             status: self.status.parse().unwrap_or(IntentStatus::Pending),
             tx_hash: self.tx_hash,
             block_number: self.block_number,
+            reason: self.reason,
         })
     }
 
@@ -92,4 +94,5 @@ pub struct IntentResponse {
     pub status: IntentStatus,
     pub tx_hash: Option<String>,
     pub block_number: Option<i64>,
+    pub reason: Option<String>,
 }

--- a/server/src/routes/intent.rs
+++ b/server/src/routes/intent.rs
@@ -111,6 +111,7 @@ pub async fn execute(
             status: IntentStatus::Pending,
             tx_hash: None,
             block_number: None,
+            reason: None,
         }),
     ))
 }
@@ -123,7 +124,7 @@ pub async fn status(
     Path(id): Path<Uuid>,
 ) -> AppResult<Json<IntentResponse>> {
     let intent: Option<DbIntent> = sqlx::query_as(
-        "SELECT id, session_id, chain, target, calldata, value_wei, status, tx_hash, block_number, created_at, updated_at
+        "SELECT id, session_id, chain, target, calldata, value_wei, status, tx_hash, block_number, reason, created_at, updated_at
          FROM intents WHERE id = ?",
     )
     .bind(id.to_string())
@@ -164,7 +165,15 @@ async fn submit_to_bundler(
         Ok(op) => op,
         Err(e) => {
             tracing::warn!(intent_id = %intent_id, error = %e, "paymaster sponsorship failed");
-            update_intent_status(&db, &intent_id, "failed", None, None).await;
+            update_intent_status(
+                &db,
+                &intent_id,
+                "failed",
+                None,
+                None,
+                Some("execution_reverted"),
+            )
+            .await;
             return;
         }
     };
@@ -174,12 +183,28 @@ async fn submit_to_bundler(
         Ok(h) => h,
         Err(e) => {
             tracing::warn!(intent_id = %intent_id, error = %e, "bundler submission failed");
-            update_intent_status(&db, &intent_id, "failed", None, None).await;
+            update_intent_status(
+                &db,
+                &intent_id,
+                "failed",
+                None,
+                None,
+                Some("execution_reverted"),
+            )
+            .await;
             return;
         }
     };
 
-    update_intent_status(&db, &intent_id, "submitted", Some(&user_op_hash), None).await;
+    update_intent_status(
+        &db,
+        &intent_id,
+        "submitted",
+        Some(&user_op_hash),
+        None,
+        None,
+    )
+    .await;
     tracing::info!(intent_id = %intent_id, user_op_hash = %user_op_hash, "intent.bundler_submitted");
 
     // Poll for receipt (30 attempts × 2s = 60s max)
@@ -190,8 +215,15 @@ async fn submit_to_bundler(
                 let block = receipt["receipt"]["blockNumber"]
                     .as_str()
                     .and_then(|s| i64::from_str_radix(s.trim_start_matches("0x"), 16).ok());
-                update_intent_status(&db, &intent_id, "confirmed", Some(&user_op_hash), block)
-                    .await;
+                update_intent_status(
+                    &db,
+                    &intent_id,
+                    "confirmed",
+                    Some(&user_op_hash),
+                    block,
+                    None,
+                )
+                .await;
                 tracing::info!(intent_id = %intent_id, "intent.confirmed");
                 return;
             }
@@ -205,7 +237,15 @@ async fn submit_to_bundler(
 
     // Timed out
     tracing::warn!(intent_id = %intent_id, "intent.poll_timeout");
-    update_intent_status(&db, &intent_id, "failed", Some(&user_op_hash), None).await;
+    update_intent_status(
+        &db,
+        &intent_id,
+        "failed",
+        Some(&user_op_hash),
+        None,
+        Some("execution_reverted"),
+    )
+    .await;
 }
 
 async fn update_intent_status(
@@ -214,14 +254,16 @@ async fn update_intent_status(
     status: &str,
     tx_hash: Option<&str>,
     block: Option<i64>,
+    reason: Option<&str>,
 ) {
     let now = Utc::now().timestamp();
     let _ = sqlx::query(
-        "UPDATE intents SET status = ?, tx_hash = ?, block_number = ?, updated_at = ? WHERE id = ?",
+        "UPDATE intents SET status = ?, tx_hash = ?, block_number = ?, reason = ?, updated_at = ? WHERE id = ?",
     )
     .bind(status)
     .bind(tx_hash)
     .bind(block)
+    .bind(reason)
     .bind(now)
     .bind(id)
     .execute(db)

--- a/server/tests/intent.rs
+++ b/server/tests/intent.rs
@@ -188,7 +188,7 @@ async fn get_intent_status_confirmed_returns_confirmed_fields() {
     );
 }
 
-// SPEC-033 (failed): after DB update to failed, status returns failed
+// SPEC-033 (failed): after DB update to failed, status returns failed + reason
 #[tokio::test]
 async fn get_intent_status_failed_returns_failed() {
     let bundler = mock_bundler().await;
@@ -214,12 +214,14 @@ async fn get_intent_status_failed_returns_failed() {
 
     // Directly update the DB to simulate a failed state
     let now = Utc::now().timestamp();
-    sqlx::query("UPDATE intents SET status = 'failed', updated_at = ? WHERE id = ?")
-        .bind(now)
-        .bind(&intent_id)
-        .execute(&pool)
-        .await
-        .expect("DB update");
+    sqlx::query(
+        "UPDATE intents SET status = 'failed', reason = 'execution_reverted', updated_at = ? WHERE id = ?",
+    )
+    .bind(now)
+    .bind(&intent_id)
+    .execute(&pool)
+    .await
+    .expect("DB update");
 
     let status_res = server
         .get(&format!("/intent/{intent_id}/status"))
@@ -229,6 +231,10 @@ async fn get_intent_status_failed_returns_failed() {
     status_res.assert_status_ok();
     let body = status_res.json::<serde_json::Value>();
     assert_eq!(body["status"], "failed");
+    assert_eq!(
+        body["reason"], "execution_reverted",
+        "SPEC-033: reason must be execution_reverted"
+    );
 }
 
 // SPEC-022: expired session key → 401 with session_expired
@@ -330,7 +336,7 @@ async fn execute_intent_invalid_calldata_returns_400() {
     assert_eq!(res.json::<serde_json::Value>()["error"], "invalid_calldata");
 }
 
-// SPEC-035: no auth → 401
+// No auth → 401 (auth guard test, not SPEC-035)
 #[tokio::test]
 async fn execute_intent_no_auth_returns_401() {
     let server = helpers::test_server().await;
@@ -347,6 +353,49 @@ async fn execute_intent_no_auth_returns_401() {
         .await;
 
     res.assert_status(StatusCode::UNAUTHORIZED);
+}
+
+// SPEC-035: intent rate limiting — 11th intent (limit: 10/60s) → 429 + Retry-After
+#[tokio::test]
+async fn execute_intent_rate_limited_returns_429() {
+    let (server, _pool) = helpers::test_server_and_db().await;
+    let (token, session_id) = setup_intent(&server, "intent-ratelimit@example.com").await;
+
+    let payload = json!({
+        "session_id": session_id,
+        "target": TEST_ADDR,
+        "calldata": VALID_CALLDATA,
+        "value": "0",
+        "user_operation": {}
+    });
+
+    // Fire 10 intents — all should succeed (rate limit: 10/60s)
+    for _ in 0..10 {
+        let res = server
+            .post("/intent/execute")
+            .add_header("Authorization", format!("Bearer {token}"))
+            .json(&payload)
+            .await;
+        res.assert_status(StatusCode::ACCEPTED);
+    }
+
+    // 11th intent — must be rate limited
+    let res = server
+        .post("/intent/execute")
+        .add_header("Authorization", format!("Bearer {token}"))
+        .json(&payload)
+        .await;
+
+    res.assert_status(StatusCode::TOO_MANY_REQUESTS);
+    assert_eq!(
+        res.json::<serde_json::Value>()["error"],
+        "rate_limited",
+        "SPEC-035: error code must be rate_limited"
+    );
+    assert!(
+        res.headers().get("retry-after").is_some(),
+        "SPEC-035: Retry-After header must be present on 429"
+    );
 }
 
 // Unknown session → 404
@@ -370,7 +419,7 @@ async fn execute_intent_unknown_session_returns_404() {
     res.assert_status(StatusCode::NOT_FOUND);
 }
 
-// Target outside allowed scope → 403
+// SPEC-021: target outside allowed scope → 403 intent_out_of_scope
 #[tokio::test]
 async fn execute_intent_out_of_scope_target_returns_403() {
     let server = helpers::test_server().await;
@@ -389,9 +438,14 @@ async fn execute_intent_out_of_scope_target_returns_403() {
         .await;
 
     res.assert_status(StatusCode::FORBIDDEN);
+    assert_eq!(
+        res.json::<serde_json::Value>()["error"],
+        "intent_out_of_scope",
+        "SPEC-021: error code must be intent_out_of_scope"
+    );
 }
 
-// Value above session max → 403
+// SPEC-023: value above session max → 403 value_exceeds_session_limit
 #[tokio::test]
 async fn execute_intent_value_exceeds_limit_returns_403() {
     let server = helpers::test_server().await;
@@ -410,4 +464,9 @@ async fn execute_intent_value_exceeds_limit_returns_403() {
         .await;
 
     res.assert_status(StatusCode::FORBIDDEN);
+    assert_eq!(
+        res.json::<serde_json::Value>()["error"],
+        "value_exceeds_session_limit",
+        "SPEC-023: error code must be value_exceeds_session_limit"
+    );
 }

--- a/server/tests/security.rs
+++ b/server/tests/security.rs
@@ -16,12 +16,16 @@ async fn oversized_payload_returns_413() {
     res.assert_status(axum::http::StatusCode::PAYLOAD_TOO_LARGE);
 }
 
-// SPEC-203: wrong HTTP method returns 405
+// SPEC-203: wrong HTTP method returns 405 + Allow header
 #[tokio::test]
 async fn wrong_method_returns_405() {
     let server = helpers::test_server().await;
     let res = server.put("/auth/login").json(&json!({})).await;
     res.assert_status(axum::http::StatusCode::METHOD_NOT_ALLOWED);
+    assert!(
+        res.headers().get("allow").is_some(),
+        "SPEC-203: Allow header must be present on 405"
+    );
 }
 
 // SPEC-201: SQL injection in login credential is safely handled


### PR DESCRIPTION
## Summary
Fixes all Phase 1 validation gaps found during post-v0.3.1 revalidation.

- **SPEC-035** (#50): Real intent rate-limit test — fires 10 intents, asserts 11th → 429 + Retry-After + `"rate_limited"`. Old mislabeled test (no-auth → 401) renamed.
- **SPEC-033** (#51): `reason` field added to failed intent response — migration `0002_intent_reason.sql`, `DbIntent`/`IntentResponse` updated, `update_intent_status` sets `"execution_reverted"`, test asserts it.
- **SPEC-021/023** (#52): Error code assertions added — `intent_out_of_scope` and `value_exceeds_session_limit`.
- **SPEC-203** (#53): `Allow` header asserted in 405 test.
- **TEST_SPECS.md**: SPEC-035 corrected — limit is 10/60s (was 20/60s), 11th request (was 21st).

## Test count
33 Rust tests (was 32 — +1 SPEC-035 rate limit test), 0 ignored, all passing locally.

## Checklist
- [x] `cargo fmt` clean
- [x] All 33 tests pass locally
- [x] Migration file included

🤖 Generated with [Claude Code](https://claude.com/claude-code)