### PR TITLE
docs: SPEC-003 stateless JWT decision + promote to main

### DIFF
--- a/docs/agents/DECISIONS.md
+++ b/docs/agents/DECISIONS.md
@@ -96,3 +96,21 @@ Format: append-only. To reverse a decision, add a `Superseded by:` line.
 **Risks:** Slightly slower iteration if CI is slow. Mitigated by fast Rust test suite (< 30s).
 **Reviewed by:** Orchestrator ✓
 **Status:** Accepted
+
+---
+
+## 2026-03-26 — Founder — Stateless JWT: No Token Denylist for v0
+
+**Phase:** Post-Phase 3 (Validation)
+**Context:** SPEC-003 specified that refreshing a token must invalidate the old token. Validation (issue #54) surfaced that current implementation uses stateless JWTs — old tokens remain valid until their `exp` claim expires (1-hour TTL). Implementing invalidation would require a token denylist (DB or Redis lookup on every authenticated request).
+**Decision:** Accept stateless JWT behavior for v0. Do not implement a token denylist. SPEC-003 updated to remove the old-token-invalidation requirement.
+**Rationale:**
+- 1-hour TTL limits blast radius of a leaked JWT to 60 minutes
+- Non-custodial architecture provides a second security layer: even with a valid JWT, an attacker cannot move funds they don't control; session keys are separately scoped per-target/selector/value
+- Token denylist adds per-request DB overhead, infrastructure complexity, and a new failure mode (denylist unavailable → auth broken)
+- Stateless JWT is standard practice for short-lived tokens in non-custodial systems
+**Risks:** If a JWT is stolen, attacker has up to 1 hour of API access. Mitigated by: short TTL, session key scope enforcement, rate limiting, non-custodial key model.
+**Future:** Revisit for v1 if compliance requirements (e.g., immediate revocation on logout) demand it. Adding a denylist is backwards-compatible — no API changes required.
+**Reviewed by:** Security Lead ✓ | Founder ✓
+**Status:** Accepted
+**Supersedes:** SPEC-003 old-token-invalidation requirement (issue #54)

--- a/docs/agents/TEST_SPECS.md
+++ b/docs/agents/TEST_SPECS.md
@@ -55,7 +55,9 @@ GIVEN:  a valid, non-expired token
 WHEN:   POST /auth/refresh { token: <valid_token> }
 THEN:   - HTTP 200
         - new token issued with fresh expiry
-        - old token is invalidated
+NOTE:   Old token remains valid until its exp claim expires (stateless JWT).
+        Token denylist is explicitly out of scope for v0. See DECISIONS.md
+        2026-03-26 "Stateless JWT — no token denylist for v0".
 OWNER:  server/tests/auth.rs
 ```
 


### PR DESCRIPTION
## Summary
Closes SPEC-003 design discussion. Stateless JWT accepted for v0 — no token denylist.

- DECISIONS.md: rationale logged
- TEST_SPECS.md: SPEC-003 updated

## Checklist
- [x] CI green on PR #59
- [x] Issue #54 closed
- [x] No code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)