### PR TITLE
feat: Phase 4 hardening — CORS, security headers, request ID, structured logging, health 503, deployment docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,3 +11,8 @@ BASE_PAYMASTER_URL=https://api.pimlico.io/v2/8453/rpc?apikey=YOUR_KEY
 
 # Base Sepolia (dev / CI)
 BASE_SEPOLIA_RPC_URL=https://sepolia.base.org
+
+# Server
+CHAIN_ID=84532
+# Comma-separated allowed CORS origins (JSON array string for docker-compose)
+CORS_ORIGINS=["http://localhost:3000"]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,6 +33,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -373,6 +383,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "deadpool"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
+dependencies = [
+ "deadpool-runtime",
+ "lazy_static",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -458,7 +486,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -557,6 +585,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -601,6 +644,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -618,8 +672,10 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
+ "futures-macro",
  "futures-sink",
  "futures-task",
  "memchr",
@@ -688,6 +744,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "uuid",
+ "wiremock",
 ]
 
 [[package]]
@@ -746,6 +803,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -1337,6 +1400,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1775,7 +1848,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2337,7 +2410,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2592,6 +2665,7 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+ "uuid",
 ]
 
 [[package]]
@@ -3172,6 +3246,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "wiremock"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
+dependencies = [
+ "assert-json-diff",
+ "base64",
+ "deadpool",
+ "futures",
+ "http 1.4.0",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ tokio = { version = "1", features = ["full"] }
 # http
 axum = { version = "0.7", features = ["macros"] }
 tower = "0.5"
-tower-http = { version = "0.6", features = ["trace", "cors", "limit"] }
+tower-http = { version = "0.6", features = ["trace", "cors", "limit", "request-id", "set-header", "util"] }
 
 # db
 sqlx = { version = "0.8", default-features = false, features = ["runtime-tokio-native-tls", "sqlite", "macros", "migrate", "chrono", "uuid"] }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,41 @@
+# ── Build stage ──────────────────────────────────────────────────────────────
+FROM rust:1.82-bookworm AS builder
+
+WORKDIR /build
+
+# Cache dependencies before copying source
+COPY Cargo.toml Cargo.lock ./
+COPY server/Cargo.toml server/
+RUN mkdir -p server/src && echo 'fn main() {}' > server/src/main.rs
+RUN cargo build --release --manifest-path server/Cargo.toml 2>/dev/null || true
+RUN rm -rf server/src
+
+# Build the real binary
+COPY server ./server
+RUN cargo build --release --manifest-path server/Cargo.toml
+
+# ── Runtime stage ─────────────────────────────────────────────────────────────
+FROM debian:bookworm-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    libssl3 \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY --from=builder /build/target/release/ghostkey-server /app/ghostkey-server
+COPY server/migrations /app/migrations
+
+# Non-root user
+RUN useradd -r -u 1001 -s /bin/false ghostkey && chown -R ghostkey:ghostkey /app
+USER ghostkey
+
+EXPOSE 8080
+
+ENV GHOSTKEY__SERVER__LOG_FORMAT=json
+ENV GHOSTKEY__DATABASE__URL=sqlite:///data/ghostkey.db
+
+VOLUME ["/data"]
+
+CMD ["/app/ghostkey-server"]

--- a/README.md
+++ b/README.md
@@ -69,6 +69,18 @@ cp config.toml.example config.toml
 make dev
 ```
 
+### Run with Docker
+
+```bash
+cp .env.example .env
+# Fill in JWT_SECRET, BASE_BUNDLER_URL, BASE_PAYMASTER_URL in .env
+
+docker compose up -d
+curl http://localhost:8080/health
+```
+
+See [`docs/deployment.md`](docs/deployment.md) for the full production deployment guide.
+
 ### Run tests
 
 ```bash

--- a/config.toml.example
+++ b/config.toml.example
@@ -19,6 +19,10 @@
 [server]
 host = "0.0.0.0"   # bind address — use 127.0.0.1 for local-only
 port = 8080
+# Allowed CORS origins — comma-separated. Restrict in production.
+cors_origins = ["http://localhost:3000"]
+# Log format: "pretty" for local dev, "json" for production / log aggregation.
+log_format = "pretty"
 
 [database]
 url = "sqlite:./ghostkey.db"   # SQLite path; sqlite::memory: for ephemeral

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,31 @@
+version: "3.9"
+
+services:
+  server:
+    build: .
+    ports:
+      - "8080:8080"
+    volumes:
+      - ghostkey-data:/data
+    environment:
+      # Required secrets — override via .env or shell env
+      - JWT_SECRET=${JWT_SECRET:?JWT_SECRET is required}
+      - BASE_RPC_URL=${BASE_RPC_URL:-https://sepolia.base.org}
+      - BASE_BUNDLER_URL=${BASE_BUNDLER_URL:?BASE_BUNDLER_URL is required}
+      - BASE_PAYMASTER_URL=${BASE_PAYMASTER_URL:?BASE_PAYMASTER_URL is required}
+      # Server config
+      - GHOSTKEY__SERVER__CORS_ORIGINS=${CORS_ORIGINS:-["http://localhost:3000"]}
+      - GHOSTKEY__SERVER__LOG_FORMAT=json
+      - GHOSTKEY__DATABASE__URL=sqlite:///data/ghostkey.db
+      - GHOSTKEY__CHAINS__BASE__CHAIN_ID=${CHAIN_ID:-84532}
+      - GHOSTKEY__CHAINS__BASE__ENTRY_POINT=0x0000000071727De22E5E9d8BAf0edAc6f37da032
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:8080/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+    restart: unless-stopped
+
+volumes:
+  ghostkey-data:

--- a/docs/agents/STACK.md
+++ b/docs/agents/STACK.md
@@ -30,7 +30,7 @@ Updated by: Architect Agent + DevOps Agent
 ║  ├── POST /session-key/issue     → session key generation               ║
 ║  ├── POST /intent/execute        → intent submission + routing           ║
 ║  ├── GET  /intent/:id/status     → execution status                      ║
-║  └── POST /recovery/init         → recovery flow initiation              ║
+║  └── POST /recovery/initiate     → recovery flow initiation              ║
 ╚══════════════════════════════╦═══════════════════════════════════════════╝
                                ║
          ┌─────────────────────┼──────────────────────┐

--- a/docs/agents/engineering/BACKEND.md
+++ b/docs/agents/engineering/BACKEND.md
@@ -50,7 +50,7 @@ Fast, correct, minimal.
 | POST   | /session-key/issue      | session_key     |
 | POST   | /intent/execute         | intent          |
 | GET    | /intent/:id/status      | intent          |
-| POST   | /recovery/init          | recovery        |
+| POST   | /recovery/initiate      | recovery        |
 
 ---
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,147 @@
+# Deployment Guide
+
+## Overview
+
+GhostKey server is a single Rust binary backed by SQLite. It can be deployed:
+
+- **Docker (recommended for production)** — multi-stage image, non-root user, health check
+- **Binary** — compile and run directly on the host
+- **docker-compose** — for single-host production or staging
+
+---
+
+## Quick Start (Docker)
+
+```bash
+# 1. Copy env template
+cp .env.example .env
+# 2. Fill in JWT_SECRET, BASE_BUNDLER_URL, BASE_PAYMASTER_URL
+
+# 3. Start
+docker compose up -d
+
+# 4. Check health
+curl http://localhost:8080/health
+```
+
+---
+
+## Environment Variables
+
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `JWT_SECRET` | **yes** | — | Min 32 chars. `openssl rand -hex 32` |
+| `BASE_BUNDLER_URL` | **yes** | — | Pimlico bundler RPC endpoint |
+| `BASE_PAYMASTER_URL` | **yes** | — | Pimlico paymaster RPC endpoint |
+| `BASE_RPC_URL` | no | `https://sepolia.base.org` | Base RPC |
+| `CHAIN_ID` | no | `84532` (Sepolia) | Set `8453` for mainnet |
+| `CORS_ORIGINS` | no | `["http://localhost:3000"]` | Allowed CORS origins (JSON array string) |
+| `GHOSTKEY__SERVER__LOG_FORMAT` | no | `pretty` | `json` for structured logging |
+| `GHOSTKEY__DATABASE__URL` | no | `sqlite:///data/ghostkey.db` | SQLite path |
+
+Full config override syntax uses `GHOSTKEY__` prefix with `__` as separator:
+```
+GHOSTKEY__AUTH__SESSION_TTL_SECONDS=7200
+GHOSTKEY__SERVER__PORT=9090
+```
+
+---
+
+## Building the Docker Image
+
+```bash
+docker build -t ghostkey-server:latest .
+```
+
+The image uses a two-stage build:
+- **Builder**: `rust:1.82-bookworm` — compiles release binary
+- **Runtime**: `debian:bookworm-slim` — minimal image with ca-certs + libssl3
+
+The server runs as non-root user `ghostkey` (UID 1001).
+
+---
+
+## Production Checklist
+
+- [ ] Set a strong `JWT_SECRET` (≥ 32 chars, random)
+- [ ] Set `CORS_ORIGINS` to your actual frontend domain(s)
+- [ ] Set `GHOSTKEY__SERVER__LOG_FORMAT=json` for log aggregation
+- [ ] Mount `/data` volume to a persistent disk
+- [ ] Put a TLS-terminating reverse proxy (nginx / Caddy) in front
+- [ ] Set `CHAIN_ID=8453` and mainnet `BASE_*` URLs for production
+- [ ] Run `GET /health` in your load balancer health check — returns 503 if DB is down
+
+---
+
+## Data Persistence
+
+SQLite database is stored at `/data/ghostkey.db` inside the container. Mount a persistent volume:
+
+```yaml
+volumes:
+  - /host/path/ghostkey-data:/data
+```
+
+Migrations run automatically at startup via `sqlx migrate run`.
+
+---
+
+## Reverse Proxy (nginx example)
+
+```nginx
+server {
+    listen 443 ssl;
+    server_name api.yourapp.com;
+
+    location / {
+        proxy_pass http://127.0.0.1:8080;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $remote_addr;
+    }
+}
+```
+
+The server reads `X-Forwarded-For` for rate limiting. Set `proxy_set_header X-Forwarded-For $remote_addr` (or `$proxy_add_x_forwarded_for` if you trust upstream proxies).
+
+---
+
+## Health Check
+
+```
+GET /health
+```
+
+Returns `200 OK` when healthy:
+```json
+{
+  "status": "ok",
+  "db": "ok",
+  "chains": { "base": "configured" },
+  "version": "0.1.0"
+}
+```
+
+Returns `503 Service Unavailable` when degraded (DB unreachable):
+```json
+{
+  "status": "degraded",
+  "db": "error",
+  "chains": { "base": "configured" },
+  "version": "0.1.0"
+}
+```
+
+---
+
+## Logging
+
+Set `GHOSTKEY__SERVER__LOG_FORMAT=json` for structured JSON logs:
+
+```json
+{"timestamp":"2026-03-25T12:00:00Z","level":"INFO","fields":{"message":"intent.submitted","intent_id":"...","target":"0x..."},...}
+```
+
+Use `RUST_LOG` to control verbosity:
+```
+RUST_LOG=ghostkey=info,tower_http=warn
+```

--- a/server/src/auth_jwt.rs
+++ b/server/src/auth_jwt.rs
@@ -29,7 +29,7 @@ pub fn issue(
         &claims,
         &EncodingKey::from_secret(secret.as_bytes()),
     )
-    .map_err(|_| AppError::Internal)?;
+    .map_err(|e| AppError::Internal(format!("jwt encode failed: {e}")))?;
     Ok((token, expires_at))
 }
 

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -18,6 +18,12 @@ pub struct ServerConfig {
     pub host: String,
     #[serde(default = "default_port")]
     pub port: u16,
+    /// Allowed CORS origins. Defaults to localhost:3000 for local dev.
+    #[serde(default = "default_cors_origins")]
+    pub cors_origins: Vec<String>,
+    /// Log format: "pretty" (default) or "json" (for production/structured logging).
+    #[serde(default = "default_log_format")]
+    pub log_format: String,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -45,6 +51,13 @@ pub struct ChainConfig {
     pub bundler_url: String,
     pub paymaster_url: String,
     pub entry_point: String,
+}
+
+fn default_cors_origins() -> Vec<String> {
+    vec!["http://localhost:3000".to_string()]
+}
+fn default_log_format() -> String {
+    "pretty".to_string()
 }
 
 fn default_host() -> String {

--- a/server/src/error.rs
+++ b/server/src/error.rs
@@ -40,8 +40,8 @@ pub enum AppError {
     #[error("database error")]
     Database(#[from] sqlx::Error),
 
-    #[error("internal error")]
-    Internal,
+    #[error("internal error: {0}")]
+    Internal(String),
 }
 
 impl IntoResponse for AppError {
@@ -76,7 +76,7 @@ impl IntoResponse for AppError {
                     }
                     AppError::InvalidCalldata => (StatusCode::BAD_REQUEST, "invalid_calldata"),
                     AppError::Database(_) => (StatusCode::INTERNAL_SERVER_ERROR, "database_error"),
-                    AppError::Internal => (StatusCode::INTERNAL_SERVER_ERROR, "internal_error"),
+                    AppError::Internal(_) => (StatusCode::INTERNAL_SERVER_ERROR, "internal_error"),
                 };
                 (status, Json(json!({ "error": code }))).into_response()
             }

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -5,15 +5,24 @@ use ghostkey::{config::Config, db, routes};
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    tracing_subscriber::registry()
-        .with(
-            tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| "ghostkey=debug,tower_http=debug".into()),
-        )
-        .with(tracing_subscriber::fmt::layer())
-        .init();
-
+    // Load config first so log_format is available before initialising tracing.
     let config = Config::load()?;
+
+    let env_filter = tracing_subscriber::EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| "ghostkey=debug,tower_http=debug".into());
+
+    // #62: JSON format for production; pretty format for local dev.
+    if config.server.log_format == "json" {
+        tracing_subscriber::registry()
+            .with(env_filter)
+            .with(tracing_subscriber::fmt::layer().json())
+            .init();
+    } else {
+        tracing_subscriber::registry()
+            .with(env_filter)
+            .with(tracing_subscriber::fmt::layer())
+            .init();
+    }
     tracing::info!(host = %config.server.host, port = %config.server.port, "starting ghostkey-server");
 
     let pool = db::connect(&config.database.url).await?;

--- a/server/src/routes/account.rs
+++ b/server/src/routes/account.rs
@@ -34,7 +34,11 @@ pub async fn create(
     if let Some(account) = existing {
         return Ok((
             StatusCode::OK,
-            Json(account.into_response().map_err(|_| AppError::Internal)?),
+            Json(
+                account
+                    .into_response()
+                    .map_err(|_| AppError::Internal("account uuid parse failed".into()))?,
+            ),
         ));
     }
 
@@ -80,14 +84,15 @@ pub async fn fetch(
 
     let account = account.ok_or(AppError::NotFound)?;
 
-    let owner_id = Uuid::parse_str(&account.user_id).map_err(|_| AppError::Internal)?;
+    let owner_id = Uuid::parse_str(&account.user_id)
+        .map_err(|_| AppError::Internal("account user_id parse failed".into()))?;
     if owner_id != auth.user_id {
         return Err(AppError::Forbidden); // SPEC-012
     }
 
-    Ok(Json(
-        account.into_response().map_err(|_| AppError::Internal)?,
-    ))
+    Ok(Json(account.into_response().map_err(|_| {
+        AppError::Internal("account uuid parse failed".into())
+    })?))
 }
 
 fn validate_evm_address(addr: &str) -> AppResult<()> {

--- a/server/src/routes/auth.rs
+++ b/server/src/routes/auth.rs
@@ -38,7 +38,11 @@ pub async fn login(
     .await?;
 
     let (user_id, is_new) = match existing {
-        Some(u) => (u.user_id().map_err(|_| AppError::Internal)?, false),
+        Some(u) => (
+            u.user_id()
+                .map_err(|_| AppError::Internal("user_id parse failed".into()))?,
+            false,
+        ),
         None => {
             let id = Uuid::new_v4();
             sqlx::query(

--- a/server/src/routes/health.rs
+++ b/server/src/routes/health.rs
@@ -1,16 +1,26 @@
-use axum::{extract::State, Json};
+use axum::{extract::State, http::StatusCode, response::IntoResponse, Json};
 use serde_json::{json, Value};
 
 use crate::routes::AppState;
 
+/// GET /health — returns 200 OK when healthy, 503 Service Unavailable when degraded.
+/// #65: DB check + version in response.
 #[tracing::instrument(skip(state))]
-pub async fn check(State(state): State<AppState>) -> Json<Value> {
+pub async fn check(State(state): State<AppState>) -> impl IntoResponse {
     let db_ok = sqlx::query("SELECT 1").execute(&state.db).await.is_ok();
 
-    Json(json!({
+    let body: Value = json!({
         "status": if db_ok { "ok" } else { "degraded" },
         "db": if db_ok { "ok" } else { "error" },
         "chains": { "base": "configured" },
         "version": env!("CARGO_PKG_VERSION"),
-    }))
+    });
+
+    let status = if db_ok {
+        StatusCode::OK
+    } else {
+        StatusCode::SERVICE_UNAVAILABLE
+    };
+
+    (status, Json(body))
 }

--- a/server/src/routes/intent.rs
+++ b/server/src/routes/intent.rs
@@ -69,7 +69,10 @@ pub async fn execute(
             .await?;
 
     let (account_user_id,) = account_row.ok_or(AppError::NotFound)?;
-    if Uuid::parse_str(&account_user_id).map_err(|_| AppError::Internal)? != auth.user_id {
+    if Uuid::parse_str(&account_user_id)
+        .map_err(|_| AppError::Internal("account user_id parse failed".into()))?
+        != auth.user_id
+    {
         return Err(AppError::Forbidden);
     }
 
@@ -144,13 +147,16 @@ pub async fn status(
     .await?;
 
     let (owner_id,) = owner_row.ok_or(AppError::NotFound)?;
-    if Uuid::parse_str(&owner_id).map_err(|_| AppError::Internal)? != auth.user_id {
+    if Uuid::parse_str(&owner_id)
+        .map_err(|_| AppError::Internal("intent owner_id parse failed".into()))?
+        != auth.user_id
+    {
         return Err(AppError::Forbidden);
     }
 
-    Ok(Json(
-        intent.into_response().map_err(|_| AppError::Internal)?,
-    ))
+    Ok(Json(intent.into_response().map_err(|_| {
+        AppError::Internal("intent uuid parse failed".into())
+    })?))
 }
 
 /// Background task: submit signed UserOp to Pimlico, poll for receipt, update DB.

--- a/server/src/routes/mod.rs
+++ b/server/src/routes/mod.rs
@@ -1,10 +1,17 @@
 use std::sync::Arc;
 
 use axum::{
+    http::{header, HeaderName, HeaderValue, Method},
     routing::{get, post},
     Router,
 };
-use tower_http::{cors::CorsLayer, limit::RequestBodyLimitLayer, trace::TraceLayer};
+use tower_http::{
+    cors::CorsLayer,
+    limit::RequestBodyLimitLayer,
+    request_id::{MakeRequestUuid, PropagateRequestIdLayer, SetRequestIdLayer},
+    set_header::SetResponseHeaderLayer,
+    trace::TraceLayer,
+};
 
 use crate::{chain::ChainAdapter, config::Config, db::Db, middleware::RateLimiter};
 
@@ -27,12 +34,17 @@ pub fn build(db: Db, config: Config) -> Router {
     let rate_limiter = Arc::new(RateLimiter::new(10, 60)); // 10 req / 60s per key
     let chain = Arc::new(ChainAdapter::new(&config.chains.base));
 
+    // Build CORS from configured origins — #61
+    let cors = build_cors(&config.server.cors_origins);
+
     let state = AppState {
         db,
         config,
         rate_limiter,
         chain,
     };
+
+    let request_id_header = HeaderName::from_static("x-request-id");
 
     Router::new()
         .route("/health", get(health::check))
@@ -46,6 +58,36 @@ pub fn build(db: Db, config: Config) -> Router {
         .route("/recovery/initiate", post(recovery::init))
         .layer(TraceLayer::new_for_http())
         .layer(RequestBodyLimitLayer::new(1024 * 1024)) // 1MB — SPEC-202
-        .layer(CorsLayer::permissive())
+        .layer(cors)
+        // Security headers — #64
+        .layer(SetResponseHeaderLayer::overriding(
+            header::HeaderName::from_static("x-content-type-options"),
+            HeaderValue::from_static("nosniff"),
+        ))
+        .layer(SetResponseHeaderLayer::overriding(
+            header::HeaderName::from_static("x-frame-options"),
+            HeaderValue::from_static("DENY"),
+        ))
+        .layer(SetResponseHeaderLayer::overriding(
+            header::HeaderName::from_static("referrer-policy"),
+            HeaderValue::from_static("strict-origin-when-cross-origin"),
+        ))
+        // Request ID — #62
+        .layer(PropagateRequestIdLayer::new(request_id_header.clone()))
+        .layer(SetRequestIdLayer::new(request_id_header, MakeRequestUuid))
         .with_state(state)
+}
+
+fn build_cors(origins: &[String]) -> CorsLayer {
+    let allowed: Vec<HeaderValue> = origins.iter().filter_map(|o| o.parse().ok()).collect();
+
+    if allowed.is_empty() {
+        // Deny all cross-origin requests if misconfigured
+        CorsLayer::new()
+    } else {
+        CorsLayer::new()
+            .allow_origin(allowed)
+            .allow_methods([Method::GET, Method::POST, Method::OPTIONS])
+            .allow_headers([header::AUTHORIZATION, header::CONTENT_TYPE])
+    }
 }

--- a/server/src/routes/session_key.rs
+++ b/server/src/routes/session_key.rs
@@ -24,7 +24,8 @@ pub async fn issue(
             .await?;
 
     let (account_user_id,) = account_row.ok_or(AppError::NotFound)?;
-    let account_owner = Uuid::parse_str(&account_user_id).map_err(|_| AppError::Internal)?;
+    let account_owner = Uuid::parse_str(&account_user_id)
+        .map_err(|_| AppError::Internal("account user_id parse failed".into()))?;
     if account_owner != auth.user_id {
         return Err(AppError::Forbidden);
     }

--- a/server/tests/helpers.rs
+++ b/server/tests/helpers.rs
@@ -33,6 +33,8 @@ pub async fn test_server_and_db_with_bundler(
         server: ServerConfig {
             host: "127.0.0.1".to_string(),
             port: 0,
+            cors_origins: vec!["http://localhost:3000".to_string()],
+            log_format: "pretty".to_string(),
         },
         database: DatabaseConfig {
             url: "sqlite::memory:".to_string(),


### PR DESCRIPTION
## Summary

Phase 4 hardening — all CI green on dev (33 tests, 0 failures).

- **#33** `AppError::Internal(String)` — 9 call sites now carry descriptive cause strings, logged on every internal error
- **#61** CORS: `CorsLayer::permissive()` replaced with config-driven `cors_origins`; defaults to `["http://localhost:3000"]`
- **#62** Request ID (`X-Request-ID` UUID on every request) + JSON log format toggle (`log_format = "json"`)
- **#64** Security headers: `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, `Referrer-Policy: strict-origin-when-cross-origin`
- **#65** Health endpoint returns `503 Service Unavailable` when DB is degraded (was always 200)
- **#63** Deployment docs: `Dockerfile`, `docker-compose.yml`, `docs/deployment.md`, `.env.example` extended, README Docker quickstart
- Stale doc fix: `/recovery/init` → `/recovery/initiate` in `STACK.md` + `BACKEND.md`

## Closes

Closes #33, #61, #62, #63, #64, #65

## Test plan

- [x] 33 tests pass locally on dev
- [x] CI green on feat/phase4-hardening (run 23574519625)
- [x] CI green on dev post-merge (run 23575089499)

🤖 Generated with [Claude Code](https://claude.com/claude-code)