### PR TITLE
docs(ops): v0.4.1 post-deploy — update HEALTH, DEPLOYMENTS, CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,48 @@ _Nothing unreleased yet._
 
 ---
 
+## [0.4.1] — 2026-03-26
+
+### Tests
+- Security headers — assert `X-Content-Type-Options`, `X-Frame-Options`, `Referrer-Policy` on every response (closes #69)
+- Request ID — assert `X-Request-ID` header is present and a valid UUID (closes #70)
+- CORS — assert configured origin is allowed; unapproved origin is denied (closes #71)
+- Health 503 — assert `GET /health` returns `503` + `"status": "degraded"` when DB pool is closed (closes #72)
+- Internal error isolation — assert `AppError::Internal` returns `{ "error": "internal_error" }` without leaking cause (closes #73)
+- New `server/tests/health.rs` test file
+- **Total: 40 Rust tests + 38 SDK = 78 total (was 70)**
+
+---
+
+## [0.4.0] — 2026-03-26
+
+### Security
+- CORS hardening — replaced `CorsLayer::permissive()` with config-driven `cors_origins`; defaults to `["http://localhost:3000"]` (closes #61)
+- Security headers on every response — `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, `Referrer-Policy: strict-origin-when-cross-origin` (closes #64)
+- `AppError::Internal(String)` — internal errors carry a descriptive cause string, logged server-side but never returned to clients (closes #33)
+
+### Observability
+- Request ID middleware — every request gets a `X-Request-ID` UUID header (closes #62)
+- Structured logging — `log_format = "json"` config field enables JSON tracing output for log aggregation (closes #62)
+
+### Reliability
+- `GET /health` returns `503 Service Unavailable` when DB check fails; `200 OK` when healthy (closes #65)
+
+### Deployment
+- `Dockerfile` — multi-stage build, non-root `ghostkey` user (UID 1001), SQLite volume at `/data` (closes #63)
+- `docker-compose.yml` — required env var validation, health check wired (closes #63)
+- `docs/deployment.md` — full production checklist, reverse proxy guide, env var reference (closes #63)
+- `README.md` — Docker quickstart section added
+
+### Config
+New optional fields in `[server]`:
+```toml
+cors_origins = ["http://localhost:3000"]
+log_format = "pretty"   # or "json"
+```
+
+---
+
 ## [0.3.1] — 2026-03-25
 
 ### Fixed

--- a/docs/agents/HEALTH.md
+++ b/docs/agents/HEALTH.md
@@ -1,32 +1,32 @@
 # GhostKey — System Health Dashboard
 
 **Maintained by:** Governor Agent
-**Last Updated:** 2026-03-25 (post-deploy #4 — v0.3.1)
-**Next Scheduled Assessment:** 2026-04-01
+**Last Updated:** 2026-03-26 (post-deploy #6 — v0.4.1)
+**Next Scheduled Assessment:** 2026-04-02
 
 ---
 
 ## Current System State
 
 ```
-OVERALL: HEALTHY — v0.3.1 on main — Phase 3 COMPLETE — Phase 4 READY
+OVERALL: HEALTHY — v0.4.1 on main — Phase 4 COMPLETE — Phase 5 READY
 ──────────────────────────────────────────────────────────────────────
 AGENT CORP:        ✓ 18 agents defined
-DOCS CURRENCY:     ✓ All docs fresh (updated 2026-03-25)
+DOCS CURRENCY:     ✓ All docs fresh (updated 2026-03-26)
 DRIFT FINDINGS:    ✓ 0 open
 SECURITY FINDINGS: ✓ 0 open
-PHASE PROGRESS:    Phase 3 COMPLETE — Phase 4 next
+PHASE PROGRESS:    Phase 4 COMPLETE — Phase 5 next
 REPO:              ✓ Public on GitHub — OriginalLeeDunn/projekt.ReaperKey
-BRANCHES:          ✓ main (v0.3.1) + dev (synced)
+BRANCHES:          ✓ main (v0.4.1) + dev (synced)
 CI:                ✓ All green — rust + sdk + security + coverage
-TESTS PASSING:     ✓ 32 Rust + 38 SDK = 70 total
+TESTS PASSING:     ✓ 40 Rust + 38 SDK = 78 total
 TESTS IGNORED:     0
-COVERAGE:          87.18%+ Rust (gate: 80%) | 96.83% SDK lines / 80.48% branches
-README:            ✓ Live
-CHANGELOG:         ✓ v0.1.0 + v0.2.0 + v0.3.0 + v0.3.1 published
-DEPLOYMENTS LOG:   ✓ Deployments #1 through #4 recorded
-RELEASES:          ✓ v0.1.0 + v0.2.0 + v0.3.0 + v0.3.1 on GitHub
-OPEN ISSUES:       1 (#33 — error cause logging, Phase 4 scope)
+COVERAGE:          80%+ Rust (gate: 80%) | 96.83% SDK lines / 80.48% branches
+README:            ✓ Live — Docker quickstart added
+CHANGELOG:         ✓ v0.1.0–v0.4.1 published
+DEPLOYMENTS LOG:   ✓ Deployments #1 through #6 recorded
+RELEASES:          ✓ v0.1.0–v0.4.1 on GitHub
+OPEN ISSUES:       0
 ```
 
 ---

--- a/docs/agents/ops/DEPLOYMENTS.md
+++ b/docs/agents/ops/DEPLOYMENTS.md
@@ -1,7 +1,7 @@
 # ReaperKey — Deployment Registry
 
 **Maintained by:** Monitor Agent + DevOps Agent
-**Last Updated:** 2026-03-25 (post-deploy #4)
+**Last Updated:** 2026-03-26 (post-deploy #6)
 **Source:** https://github.com/OriginalLeeDunn/projekt.ReaperKey
 
 This is the authoritative record of all deployments to `main`.
@@ -18,27 +18,29 @@ Append-only — to record a rollback, add a new entry with type `ROLLBACK`.
 | 2 | 2026-03-25 | v0.2.0 | efce0e5 Phase 2: SDK — hooks, mappers, intent tests | RELEASE | ✓ all green | Health: ok | #18, #19, #20, #21 |
 | 3 | 2026-03-25 | v0.3.0 | 1b23d76 Phase 3: reference app, useRecovery, generateSessionKey, auth bug fix | RELEASE | ✓ all green | Health: ok | #33 |
 | 4 | 2026-03-25 | v0.3.1 | 4a5aac1 Pre-Phase 4: validation gap fixes #36–#43 | PATCH | ✓ all green | Health: ok | #33 |
+| 5 | 2026-03-26 | v0.4.0 | 1d7c6b7 Phase 4: CORS, security headers, request ID, structured logging, health 503, deployment docs | RELEASE | ✓ all green | Health: ok | #69–#73 |
+| 6 | 2026-03-26 | v0.4.1 | fffc660 Phase 4 validation gaps: security headers, request ID, CORS, health 503, internal error isolation tests | PATCH | ✓ all green | Health: ok | None |
 
 ---
 
 ## Current Production State
 
 ```
-Environment:   v0.3.1 — merged to main 2026-03-25
-Branch:        main (commit 4a5aac1)
-Last CI Run:   2026-03-25 — all green
+Environment:   v0.4.1 — merged to main 2026-03-26
+Branch:        main (commit fffc660)
+Last CI Run:   2026-03-26 — all green
                ✓ rust (fmt + clippy + test + audit)
-               ✓ security (SPEC-200, SPEC-201, SPEC-202, SPEC-203)
+               ✓ security (SPEC-200, SPEC-201, SPEC-202, SPEC-203 + Phase 4 hardening tests)
                ✓ sdk (vitest 38 passing, coverage 96.83%, eslint clean)
-               ✓ coverage — 87.18%+ Rust (gate: 80%)
-Phase:         Phase 3 COMPLETE — Phase 4 READY
-Tests passing: 32 Rust (7 auth + 4 security + 4 account + 3 session_key + 2 recovery
-                       + 12 intent [incl. SPEC-022/031/032/033] + 1 health check [wait wrong count])
+               ✓ coverage — 80%+ Rust (gate: 80%)
+Phase:         Phase 4 COMPLETE — Phase 5 READY
+Tests passing: 40 Rust (7 auth + 9 security + 4 account + 3 session_key + 2 recovery
+                       + 13 intent + 2 health)
                + 38 SDK (15 client + 19 hook tests + 4 crypto tests)
 Tests ignored: 0
-Coverage:      87.18%+ Rust | 96.83% SDK lines, 100% funcs, 80.48% branches
-Releases:      v0.1.0 + v0.2.0 + v0.3.0 + v0.3.1 published on GitHub
-Open issues:   1 (#33 — Phase 4 scope)
+Coverage:      80%+ Rust | 96.83% SDK lines, 100% funcs, 80.48% branches
+Releases:      v0.1.0–v0.4.1 published on GitHub
+Open issues:   0
 ```
 
 ---


### PR DESCRIPTION
Post-deploy documentation update for v0.4.0 + v0.4.1.

- CHANGELOG: added [0.4.0] and [0.4.1] sections
- HEALTH.md: updated system state to Phase 4 COMPLETE, 78 tests, 0 open issues
- DEPLOYMENTS.md: added registry rows #5 (v0.4.0) and #6 (v0.4.1), updated current production state

🤖 Generated with [Claude Code](https://claude.com/claude-code)