### PR TITLE
[QA Engineer] test: Phase 6 gate — real Base Sepolia + Pimlico E2E bundler test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,39 @@ jobs:
       - name: Dependency audit
         run: npm audit --audit-level high
 
+  # ── E2E Bundler Test (Base Sepolia + live Pimlico) ──────────────────────────
+  # Runs on push to main and PRs targeting main only.
+  # Requires PIMLICO_API_KEY, BASE_SEPOLIA_RPC_URL, E2E_OWNER_PRIVATE_KEY secrets.
+  # Resolves issue #101 — Phase 6 gate test (QA hard rule).
+  e2e-bundler:
+    name: E2E — Base Sepolia + Pimlico (Phase 6 gate)
+    runs-on: ubuntu-latest
+    if: |
+      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+      (github.event_name == 'pull_request' && github.base_ref == 'main')
+    defaults:
+      run:
+        working-directory: sdk
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: sdk/package-lock.json
+
+      - name: Install deps
+        run: npm ci
+
+      - name: E2E bundler test (real Base Sepolia + Pimlico)
+        run: npm run test:e2e
+        env:
+          PIMLICO_API_KEY: ${{ secrets.PIMLICO_API_KEY }}
+          BASE_SEPOLIA_RPC_URL: ${{ secrets.BASE_SEPOLIA_RPC_URL }}
+          E2E_OWNER_PRIVATE_KEY: ${{ secrets.E2E_OWNER_PRIVATE_KEY }}
+
   # ── Security Gates ──────────────────────────────────────────────────────────
   security:
     name: Security — SPEC-200 through SPEC-203

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -18,6 +18,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
+    "test:e2e": "vitest run --config vitest.e2e.config.ts",
     "lint": "eslint src --ext .ts,.tsx",
     "lint:fix": "eslint src --ext .ts,.tsx --fix"
   },

--- a/sdk/tests/e2e.bundler.test.ts
+++ b/sdk/tests/e2e.bundler.test.ts
@@ -1,0 +1,166 @@
+// e2e.bundler.test.ts — Phase 6 gate: real Base Sepolia + live Pimlico
+//
+// This test is SKIPPED unless the following environment variables are set:
+//   PIMLICO_API_KEY        — Pimlico dashboard API key
+//   BASE_SEPOLIA_RPC_URL   — Base Sepolia RPC endpoint (Alchemy / Infura / public)
+//   E2E_OWNER_PRIVATE_KEY  — Owner EOA private key (HD test wallet, no real funds needed)
+//
+// The Pimlico verifying paymaster sponsors all gas — the owner EOA needs no ETH.
+//
+// Flow:
+//   1. Derive owner EOA from E2E_OWNER_PRIVATE_KEY
+//   2. Compute Kernel v2.4 counterfactual address (no deployment required)
+//   3. Generate ephemeral session key
+//   4. Build a zero-value UserOp (calldata = 0x, target = self) via Pimlico paymaster
+//   5. Submit via eth_sendUserOperation
+//   6. Poll Pimlico for UserOp receipt (up to 60s)
+//   7. Assert final status is 'success' and receipt contains a txHash
+//
+// Resolves: issue #101 — Phase 6 gate test (QA hard rule)
+
+import { describe, it, expect, beforeAll } from 'vitest'
+import { privateKeyToAccount, generatePrivateKey } from 'viem/accounts'
+import { buildUserOperation } from '../src/userop.js'
+import { getKernelAddressFromPrivateKey } from '../src/kernel-address.js'
+
+// ── Gate: skip if secrets not available ──────────────────────────────────────
+
+const PIMLICO_API_KEY      = process.env.PIMLICO_API_KEY
+const BASE_SEPOLIA_RPC_URL = process.env.BASE_SEPOLIA_RPC_URL
+const OWNER_PRIVATE_KEY    = process.env.E2E_OWNER_PRIVATE_KEY as `0x${string}` | undefined
+
+const SKIP = !PIMLICO_API_KEY || !BASE_SEPOLIA_RPC_URL || !OWNER_PRIVATE_KEY
+
+const CHAIN_ID = 84532 // Base Sepolia
+
+function pimlicoUrl(apiKey: string): string {
+  return `https://api.pimlico.io/v2/base-sepolia/rpc?apikey=${apiKey}`
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+async function pollForReceipt(
+  bundlerUrl: string,
+  userOpHash: string,
+  timeoutMs = 60_000,
+): Promise<{ success: boolean; receipt: Record<string, unknown> }> {
+  const deadline = Date.now() + timeoutMs
+
+  while (Date.now() < deadline) {
+    await new Promise(r => setTimeout(r, 3000))
+
+    const res = await fetch(bundlerUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'eth_getUserOperationReceipt',
+        params: [userOpHash],
+      }),
+    })
+
+    const json = await res.json()
+    if (json.result && json.result !== null) {
+      return {
+        success: json.result.success === true,
+        receipt: json.result,
+      }
+    }
+  }
+
+  throw new Error(`UserOp ${userOpHash} not confirmed within ${timeoutMs}ms`)
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe.skipIf(SKIP)(
+  'E2E: Base Sepolia + live Pimlico paymaster',
+  () => {
+    let kernelAddress: `0x${string}`
+    let sessionKeyPrivateKey: `0x${string}`
+    let bundlerUrl: string
+
+    beforeAll(async () => {
+      bundlerUrl = pimlicoUrl(PIMLICO_API_KEY!)
+
+      // Compute Kernel counterfactual address for the owner
+      kernelAddress = await getKernelAddressFromPrivateKey({
+        ownerPrivateKey: OWNER_PRIVATE_KEY!,
+        chainId: CHAIN_ID,
+        rpcUrl: BASE_SEPOLIA_RPC_URL!,
+      })
+
+      // Generate an ephemeral session key for this test run
+      sessionKeyPrivateKey = generatePrivateKey()
+
+      console.info(`[E2E] Kernel address:     ${kernelAddress}`)
+      console.info(`[E2E] Session key addr:   ${privateKeyToAccount(sessionKeyPrivateKey).address}`)
+      console.info(`[E2E] Chain:              Base Sepolia (${CHAIN_ID})`)
+    })
+
+    it('builds a sponsored UserOp and receives a userOpHash from Pimlico', async () => {
+      const userOp = await buildUserOperation({
+        sender: kernelAddress,
+        sessionKeyPrivateKey,
+        target: kernelAddress,   // self-call, no-op
+        calldata: '0x',
+        value: BigInt(0),
+        chainId: CHAIN_ID,
+        rpcUrl: BASE_SEPOLIA_RPC_URL!,
+        bundlerUrl,
+      })
+
+      expect(userOp.sender).toBe(kernelAddress)
+      expect(userOp.signature).toMatch(/^0x[0-9a-f]+$/)
+      // Gas fields populated by Pimlico
+      expect(BigInt(userOp.callGasLimit)).toBeGreaterThan(0n)
+      expect(BigInt(userOp.verificationGasLimit)).toBeGreaterThan(0n)
+      expect(userOp.paymasterAndData).not.toBe('0x')
+    }, 30_000)
+
+    it('submits UserOp to bundler and polls to confirmed', async () => {
+      const userOp = await buildUserOperation({
+        sender: kernelAddress,
+        sessionKeyPrivateKey,
+        target: kernelAddress,
+        calldata: '0x',
+        value: BigInt(0),
+        chainId: CHAIN_ID,
+        rpcUrl: BASE_SEPOLIA_RPC_URL!,
+        bundlerUrl,
+      })
+
+      // Submit
+      const sendRes = await fetch(bundlerUrl, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'eth_sendUserOperation',
+          params: [userOp, '0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789'],
+        }),
+      })
+      const sendJson = await sendRes.json()
+
+      if (sendJson.error) {
+        // Surface the Pimlico error clearly
+        throw new Error(`eth_sendUserOperation failed: ${JSON.stringify(sendJson.error)}`)
+      }
+
+      const userOpHash: string = sendJson.result
+      expect(userOpHash).toMatch(/^0x[0-9a-f]{64}$/)
+      console.info(`[E2E] UserOp hash: ${userOpHash}`)
+
+      // Poll until confirmed
+      const { success, receipt } = await pollForReceipt(bundlerUrl, userOpHash, 60_000)
+
+      const txHash = (receipt as Record<string, Record<string, string>>).receipt?.transactionHash
+      console.info(`[E2E] Confirmed. txHash: ${txHash}`)
+
+      expect(success).toBe(true)
+      expect(txHash).toMatch(/^0x[0-9a-f]{64}$/)
+    }, 90_000)
+  },
+)

--- a/sdk/vitest.config.ts
+++ b/sdk/vitest.config.ts
@@ -5,8 +5,9 @@ export default defineConfig({
     environment: 'jsdom',
     globals: false,
     setupFiles: ['./tests/setup.crypto.ts'],
+    exclude: ['**/node_modules/**', '**/dist/**', 'tests/e2e.bundler.test.ts'],
     coverage: {
-      exclude: ['**/index.ts'],
+      exclude: ['**/index.ts', '**/vitest.e2e.config.ts'],
       thresholds: {
         lines: 80,
         functions: 80,

--- a/sdk/vitest.e2e.config.ts
+++ b/sdk/vitest.e2e.config.ts
@@ -1,0 +1,14 @@
+// Separate Vitest config for E2E bundler tests.
+// Used by the `e2e-bundler` CI job (runs on main + release PRs only).
+// Unit tests use vitest.config.ts; this config excludes coverage thresholds.
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'node',   // No jsdom needed — pure network calls
+    globals: false,
+    include: ['tests/e2e.bundler.test.ts'],
+    setupFiles: ['./tests/setup.crypto.ts'],
+    testTimeout: 120_000,  // 2 minutes — allows for bundler + poll latency
+  },
+})


### PR DESCRIPTION
## Summary

- Adds `sdk/tests/e2e.bundler.test.ts` — real testnet E2E per QA hard rule (Phase 6 gate)
- Test skips gracefully if secrets not configured; CI job only runs on pushes to `main` and PRs targeting `main`
- Adds `vitest.e2e.config.ts` + `test:e2e` npm script
- Adds `e2e-bundler` CI job to `.github/workflows/ci.yml`

## Test flow
1. Compute Kernel v2.4 counterfactual address from owner private key
2. Generate ephemeral session key
3. `buildUserOperation()` → Pimlico `pm_sponsorUserOperation` fills gas + paymasterAndData
4. `eth_sendUserOperation` → poll `eth_getUserOperationReceipt` until confirmed
5. Assert `success: true` + valid `transactionHash`

## Secrets required (set once in GitHub repo settings)
```
gh secret set PIMLICO_API_KEY       --body "<key>"
gh secret set BASE_SEPOLIA_RPC_URL  --body "<url>"
gh secret set E2E_OWNER_PRIVATE_KEY --body "0x<key>"
```

## Test plan
- [ ] CI jobs (Rust, SDK unit) pass on this PR
- [ ] After secrets are configured: merge to dev → PR to main → `e2e-bundler` job runs and passes
- [ ] Phase 6 (#97) can be signed off after this passes on main

Closes #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)