### PR TITLE
feat(multi-chain): Arbitrum + Ethereum mainnet support

### DIFF
--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -42,6 +42,24 @@ pub struct AuthConfig {
 #[derive(Debug, Clone, Deserialize)]
 pub struct ChainsConfig {
     pub base: ChainConfig,
+    /// Arbitrum One (42161) — optional; enabled by setting ARBITRUM_* env vars.
+    pub arbitrum: Option<ChainConfig>,
+    /// Ethereum mainnet (1) — optional; enabled by setting ETHEREUM_* env vars.
+    pub ethereum: Option<ChainConfig>,
+}
+
+impl ChainsConfig {
+    /// Returns all configured chains as `(chain_name, config)` pairs.
+    pub fn all(&self) -> Vec<(&'static str, &ChainConfig)> {
+        let mut chains = vec![("base", &self.base)];
+        if let Some(ref a) = self.arbitrum {
+            chains.push(("arbitrum", a));
+        }
+        if let Some(ref e) = self.ethereum {
+            chains.push(("ethereum", e));
+        }
+        chains
+    }
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -84,6 +102,12 @@ impl Config {
                 "BASE_RPC_URL",
                 "BASE_BUNDLER_URL",
                 "BASE_PAYMASTER_URL",
+                "ARBITRUM_RPC_URL",
+                "ARBITRUM_BUNDLER_URL",
+                "ARBITRUM_PAYMASTER_URL",
+                "ETHEREUM_RPC_URL",
+                "ETHEREUM_BUNDLER_URL",
+                "ETHEREUM_PAYMASTER_URL",
             ]))
             .extract()?;
         Ok(config)

--- a/server/src/routes/intent.rs
+++ b/server/src/routes/intent.rs
@@ -76,10 +76,19 @@ pub async fn execute(
         return Err(AppError::Forbidden);
     }
 
+    // Look up the account's chain so we can dispatch to the right adapter
+    let chain_name_row: Option<(String,)> =
+        sqlx::query_as("SELECT chain FROM accounts WHERE id = ?")
+            .bind(&session.account_id)
+            .fetch_optional(&state.db)
+            .await?;
+    let chain = chain_name_row
+        .map(|(c,)| c)
+        .unwrap_or_else(|| "base".to_string());
+
     // Persist intent as pending
     let intent_id = Uuid::new_v4();
     let now = Utc::now().timestamp();
-    let chain = "base"; // v0: Base only
 
     sqlx::query(
         "INSERT INTO intents (id, session_id, chain, target, calldata, value_wei, status, created_at, updated_at)
@@ -87,7 +96,7 @@ pub async fn execute(
     )
     .bind(intent_id.to_string())
     .bind(body.session_id.to_string())
-    .bind(chain)
+    .bind(&chain)
     .bind(&body.target)
     .bind(&body.calldata)
     .bind(&body.value)
@@ -96,11 +105,11 @@ pub async fn execute(
     .execute(&state.db)
     .await?;
 
-    tracing::info!(intent_id = %intent_id, target = %body.target, chain = chain, "intent.submitted");
+    tracing::info!(intent_id = %intent_id, target = %body.target, chain = %chain, "intent.submitted");
 
     // Spawn background task to submit UserOp to Pimlico bundler
     let db = state.db.clone();
-    let chain_adapter = state.chain.clone();
+    let chain_adapter = state.chain_for(&chain);
     let user_op = body.user_operation.clone();
     let id_str = intent_id.to_string();
     tokio::spawn(async move {

--- a/server/src/routes/mod.rs
+++ b/server/src/routes/mod.rs
@@ -1,5 +1,6 @@
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 
+use crate::{chain::ChainAdapter, config::Config, db::Db, middleware::RateLimiter};
 use axum::{
     http::{header, HeaderName, HeaderValue, Method},
     routing::{get, post},
@@ -13,8 +14,6 @@ use tower_http::{
     trace::TraceLayer,
 };
 
-use crate::{chain::ChainAdapter, config::Config, db::Db, middleware::RateLimiter};
-
 pub mod account;
 pub mod auth;
 pub mod health;
@@ -27,12 +26,32 @@ pub struct AppState {
     pub db: Db,
     pub config: Config,
     pub rate_limiter: Arc<RateLimiter>,
-    pub chain: Arc<ChainAdapter>,
+    /// Multi-chain map: chain name (e.g. "base", "arbitrum") → adapter.
+    /// The "base" entry is always present; others are optional.
+    pub chains: Arc<HashMap<String, Arc<ChainAdapter>>>,
+}
+
+impl AppState {
+    /// Returns the chain adapter for a given chain name.
+    /// Falls back to "base" if the requested chain is not configured.
+    pub fn chain_for(&self, name: &str) -> Arc<ChainAdapter> {
+        self.chains
+            .get(name)
+            .or_else(|| self.chains.get("base"))
+            .cloned()
+            .expect("base chain always configured")
+    }
 }
 
 pub fn build(db: Db, config: Config) -> Router {
     let rate_limiter = Arc::new(RateLimiter::new(10, 60)); // 10 req / 60s per key
-    let chain = Arc::new(ChainAdapter::new(&config.chains.base));
+
+    // Build multi-chain adapter map
+    let mut chain_map: HashMap<String, Arc<ChainAdapter>> = HashMap::new();
+    for (name, cfg) in config.chains.all() {
+        chain_map.insert(name.to_string(), Arc::new(ChainAdapter::new(cfg)));
+    }
+    let chains = Arc::new(chain_map);
 
     // Build CORS from configured origins — #61
     let cors = build_cors(&config.server.cors_origins);
@@ -41,7 +60,7 @@ pub fn build(db: Db, config: Config) -> Router {
         db,
         config,
         rate_limiter,
-        chain,
+        chains,
     };
 
     let request_id_header = HeaderName::from_static("x-request-id");

--- a/server/tests/helpers.rs
+++ b/server/tests/helpers.rs
@@ -51,6 +51,8 @@ pub async fn test_server_and_db_with_bundler(
                 paymaster_url: paymaster_url.to_string(),
                 entry_point: "0x0000000071727De22E5E9d8BAf0edAc6f37da032".to_string(),
             },
+            arbitrum: None,
+            ethereum: None,
         },
     };
 


### PR DESCRIPTION
## Summary
- `ChainsConfig` adds optional `arbitrum` and `ethereum` chain fields
- `AppState` uses `Arc<HashMap<String, Arc<ChainAdapter>>>` for all configured chains
- `chain_for()` fallback to "base" if a chain is not configured
- `POST /intent/execute` reads `account.chain` from DB and dispatches to the correct adapter
- Config loads `ARBITRUM_*` / `ETHEREUM_*` / `GHOSTKEY_CHAINS__*` env vars via figment

## Test plan
- [ ] All existing Rust tests pass (no regressions)
- [ ] `cargo fmt --check` passes
- [ ] Deploying with `ARBITRUM_RPC_URL` etc. set activates Arbitrum chain adapter
- [ ] Intents on Arbitrum accounts dispatch to Arbitrum bundler (not Base)
- [ ] Missing chain gracefully falls back to "base"

🤖 Generated with [Claude Code](https://claude.com/claude-code)