### PR TITLE
feat(server): JWT denylist — immediate token invalidation on logout

### DIFF
--- a/server/migrations/0004_token_denylist.sql
+++ b/server/migrations/0004_token_denylist.sql
@@ -1,0 +1,11 @@
+-- v1.0: Token denylist for immediate JWT invalidation on logout.
+-- Stores SHA-256 hashes of revoked tokens; pruned on expiry.
+-- Using a hash rather than the full token keeps storage minimal.
+
+CREATE TABLE IF NOT EXISTS token_denylist (
+    token_hash TEXT    PRIMARY KEY,   -- SHA-256(raw_token)
+    expires_at INTEGER NOT NULL,      -- unix epoch — used to prune stale entries
+    created_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_token_denylist_expires ON token_denylist(expires_at);

--- a/server/src/auth_jwt.rs
+++ b/server/src/auth_jwt.rs
@@ -1,6 +1,7 @@
 use chrono::{DateTime, Duration, Utc};
 use jsonwebtoken::{decode, encode, DecodingKey, EncodingKey, Header, Validation};
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 use uuid::Uuid;
 
 use crate::error::AppError;
@@ -31,6 +32,14 @@ pub fn issue(
     )
     .map_err(|e| AppError::Internal(format!("jwt encode failed: {e}")))?;
     Ok((token, expires_at))
+}
+
+/// Returns the hex-encoded SHA-256 hash of a raw JWT string.
+/// Used as the primary key in the token_denylist table.
+pub fn token_hash(token: &str) -> String {
+    let mut h = Sha256::new();
+    h.update(token.as_bytes());
+    format!("{:x}", h.finalize())
 }
 
 pub fn validate(token: &str, secret: &str) -> Result<Claims, AppError> {

--- a/server/src/middleware/auth_extractor.rs
+++ b/server/src/middleware/auth_extractor.rs
@@ -30,6 +30,19 @@ impl FromRequestParts<AppState> for AuthUser {
 
         let claims = auth_jwt::validate(token, &state.config.auth.jwt_secret)?;
 
+        // Token denylist check — reject tokens explicitly revoked via POST /auth/logout
+        let hash = auth_jwt::token_hash(token);
+        let denied: Option<(String,)> =
+            sqlx::query_as("SELECT token_hash FROM token_denylist WHERE token_hash = ?")
+                .bind(&hash)
+                .fetch_optional(&state.db)
+                .await
+                .map_err(|_| AppError::Unauthorized("denylist check failed"))?;
+
+        if denied.is_some() {
+            return Err(AppError::Unauthorized("token_revoked"));
+        }
+
         let user_id = Uuid::parse_str(&claims.sub)
             .map_err(|_| AppError::Unauthorized("invalid token subject"))?;
 

--- a/server/src/routes/auth.rs
+++ b/server/src/routes/auth.rs
@@ -9,6 +9,7 @@ use uuid::Uuid;
 use crate::{
     auth_jwt,
     error::{AppError, AppResult},
+    middleware::AuthUser,
     models::user::{AuthResponse, DbUser, LoginRequest, RefreshRequest},
     routes::AppState,
 };
@@ -101,6 +102,36 @@ pub async fn refresh(
         token,
         expires_at,
     }))
+}
+
+/// POST /auth/logout — revoke the current token immediately.
+/// Adds the token's SHA-256 hash to the denylist; subsequent requests
+/// using this token will receive 401 even before natural expiry.
+#[tracing::instrument(skip(state, headers), fields(user_id = %auth.user_id))]
+pub async fn logout(
+    State(state): State<AppState>,
+    auth: AuthUser,
+    headers: HeaderMap,
+) -> AppResult<StatusCode> {
+    let token = headers
+        .get(axum::http::header::AUTHORIZATION)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.strip_prefix("Bearer "))
+        .ok_or(AppError::Unauthorized("missing token"))?;
+
+    let hash = auth_jwt::token_hash(token);
+
+    // Fetch expiry from the claims so the denylist entry can be pruned later
+    let claims = auth_jwt::validate(token, &state.config.auth.jwt_secret)?;
+
+    sqlx::query("INSERT OR IGNORE INTO token_denylist (token_hash, expires_at) VALUES (?, ?)")
+        .bind(&hash)
+        .bind(claims.exp)
+        .execute(&state.db)
+        .await?;
+
+    tracing::info!(user_id = %auth.user_id, "auth.logout");
+    Ok(StatusCode::NO_CONTENT)
 }
 
 fn hash_credential(credential: &str) -> String {

--- a/server/src/routes/mod.rs
+++ b/server/src/routes/mod.rs
@@ -50,6 +50,7 @@ pub fn build(db: Db, config: Config) -> Router {
         .route("/health", get(health::check))
         .route("/auth/login", post(auth::login))
         .route("/auth/refresh", post(auth::refresh))
+        .route("/auth/logout", post(auth::logout))
         .route("/account/create", post(account::create))
         .route("/account/:id", get(account::fetch))
         .route("/session-key/issue", post(session_key::issue))

--- a/server/tests/auth.rs
+++ b/server/tests/auth.rs
@@ -109,6 +109,57 @@ async fn expired_token_returns_401() {
     assert_eq!(res.json::<serde_json::Value>()["error"], "token_expired");
 }
 
+// Logout: POST /auth/logout → 204 No Content
+#[tokio::test]
+async fn logout_returns_204() {
+    let server = helpers::test_server().await;
+    let (token, _) = helpers::login(&server, "logout-204@example.com").await;
+
+    let res = server
+        .post("/auth/logout")
+        .add_header("Authorization", format!("Bearer {token}"))
+        .await;
+    res.assert_status(StatusCode::NO_CONTENT);
+}
+
+// Logout: token is denied on subsequent protected requests
+#[tokio::test]
+async fn logout_token_is_revoked() {
+    let server = helpers::test_server().await;
+    let (token, _) = helpers::login(&server, "logout-revoke@example.com").await;
+
+    // Create an account to verify the token works before logout
+    let pre_res = server
+        .post("/account/create")
+        .add_header("Authorization", format!("Bearer {token}"))
+        .json(&serde_json::json!({ "chain": "base", "address": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045" }))
+        .await;
+    pre_res.assert_status(StatusCode::CREATED);
+
+    // Logout
+    server
+        .post("/auth/logout")
+        .add_header("Authorization", format!("Bearer {token}"))
+        .await
+        .assert_status(StatusCode::NO_CONTENT);
+
+    // Same token must now be rejected
+    let post_res = server
+        .post("/account/create")
+        .add_header("Authorization", format!("Bearer {token}"))
+        .json(&serde_json::json!({ "chain": "base", "address": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045" }))
+        .await;
+    post_res.assert_status(StatusCode::UNAUTHORIZED);
+}
+
+// Logout: without a valid token → 401
+#[tokio::test]
+async fn logout_without_token_returns_401() {
+    let server = helpers::test_server().await;
+    let res = server.post("/auth/logout").await;
+    res.assert_status(StatusCode::UNAUTHORIZED);
+}
+
 // SPEC-006: rate limit — 11th login from same IP returns 429
 #[tokio::test]
 async fn login_rate_limit_returns_429() {


### PR DESCRIPTION
## Summary
- New `POST /auth/logout` endpoint — returns 204 No Content
- Computes SHA-256 hash of the raw JWT and stores it in `token_denylist` table
- Auth extractor checks denylist on every authenticated request; revoked tokens return 401
- Migration `0004_token_denylist.sql` creates the table with an expiry index for pruning

## Test plan
- [ ] `POST /auth/logout` with valid token → 204, subsequent requests → 401
- [ ] `POST /auth/logout` without auth header → 401
- [ ] Tokens not in denylist continue to work normally (no regression)
- [ ] All existing Rust tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)