### PR TITLE
feat(server): PostgreSQL support alongside SQLite

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ tower = "0.5"
 tower-http = { version = "0.6", features = ["trace", "cors", "limit", "request-id", "set-header", "util"] }
 
 # db
-sqlx = { version = "0.8", default-features = false, features = ["runtime-tokio-rustls", "sqlite", "macros", "migrate", "chrono", "uuid"] }
+sqlx = { version = "0.8", default-features = false, features = ["runtime-tokio-rustls", "sqlite", "postgres", "any", "macros", "migrate", "chrono", "uuid"] }
 
 # serialization
 serde = { version = "1", features = ["derive"] }

--- a/server/migrations_pg/0001_init.sql
+++ b/server/migrations_pg/0001_init.sql
@@ -1,0 +1,58 @@
+-- GhostKey initial schema — PostgreSQL
+-- Timestamps are BIGINT unix epoch seconds (app always provides the value explicitly).
+
+CREATE TABLE IF NOT EXISTS users (
+    id                   TEXT    PRIMARY KEY,  -- UUID string
+    auth_method          TEXT    NOT NULL,
+    auth_credential_hash TEXT    NOT NULL UNIQUE,
+    created_at           BIGINT  NOT NULL DEFAULT EXTRACT(EPOCH FROM NOW())::BIGINT
+);
+
+CREATE TABLE IF NOT EXISTS accounts (
+    id         TEXT    PRIMARY KEY,
+    user_id    TEXT    NOT NULL REFERENCES users(id),
+    chain      TEXT    NOT NULL,
+    address    TEXT    NOT NULL,  -- counterfactual smart account address
+    aa_type    TEXT    NOT NULL DEFAULT 'kernel',
+    created_at BIGINT  NOT NULL DEFAULT EXTRACT(EPOCH FROM NOW())::BIGINT,
+    UNIQUE(user_id, chain)  -- one account per user per chain (SPEC-013)
+);
+
+CREATE TABLE IF NOT EXISTS sessions (
+    id                TEXT    PRIMARY KEY,
+    account_id        TEXT    NOT NULL REFERENCES accounts(id),
+    key_hash          TEXT    NOT NULL,  -- client-provided SHA256 of session key
+    allowed_targets   TEXT    NOT NULL,  -- JSON array of hex addresses
+    allowed_selectors TEXT    NOT NULL,  -- JSON array of 4-byte selectors ("0xabcd1234")
+    max_value_wei     TEXT    NOT NULL,  -- wei as decimal string
+    expires_at        BIGINT  NOT NULL,  -- unix epoch
+    created_at        BIGINT  NOT NULL DEFAULT EXTRACT(EPOCH FROM NOW())::BIGINT
+);
+
+CREATE TABLE IF NOT EXISTS intents (
+    id           TEXT    PRIMARY KEY,
+    session_id   TEXT    NOT NULL REFERENCES sessions(id),
+    chain        TEXT    NOT NULL,
+    target       TEXT    NOT NULL,
+    calldata     TEXT    NOT NULL,
+    value_wei    TEXT    NOT NULL DEFAULT '0',
+    status       TEXT    NOT NULL DEFAULT 'pending',
+    tx_hash      TEXT,
+    block_number BIGINT,
+    created_at   BIGINT  NOT NULL DEFAULT EXTRACT(EPOCH FROM NOW())::BIGINT,
+    updated_at   BIGINT  NOT NULL DEFAULT EXTRACT(EPOCH FROM NOW())::BIGINT
+);
+
+CREATE TABLE IF NOT EXISTS recovery (
+    id         TEXT    PRIMARY KEY,
+    account_id TEXT    NOT NULL REFERENCES accounts(id),
+    method     TEXT    NOT NULL,
+    status     TEXT    NOT NULL DEFAULT 'initiated',
+    metadata   TEXT    NOT NULL DEFAULT '{}',
+    created_at BIGINT  NOT NULL DEFAULT EXTRACT(EPOCH FROM NOW())::BIGINT
+);
+
+CREATE INDEX IF NOT EXISTS idx_accounts_user_id    ON accounts(user_id);
+CREATE INDEX IF NOT EXISTS idx_sessions_account_id ON sessions(account_id);
+CREATE INDEX IF NOT EXISTS idx_intents_session_id  ON intents(session_id);
+CREATE INDEX IF NOT EXISTS idx_intents_status      ON intents(status);

--- a/server/migrations_pg/0002_intent_reason.sql
+++ b/server/migrations_pg/0002_intent_reason.sql
@@ -1,0 +1,2 @@
+-- Add reason column to intents table — PostgreSQL
+ALTER TABLE intents ADD COLUMN IF NOT EXISTS reason TEXT;

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -1,21 +1,36 @@
-use sqlx::{
-    sqlite::{SqliteConnectOptions, SqlitePoolOptions},
-    SqlitePool,
-};
-use std::str::FromStr;
+use sqlx::any::{install_default_drivers, AnyPoolOptions};
+use sqlx::AnyPool;
 
-pub type Db = SqlitePool;
+pub type Db = AnyPool;
 
 pub async fn connect(url: &str) -> anyhow::Result<Db> {
-    let opts = SqliteConnectOptions::from_str(url)?.create_if_missing(true);
-    let pool = SqlitePoolOptions::new()
-        .max_connections(5)
-        .connect_with(opts)
+    // Must be called once before any AnyPool connection is established.
+    install_default_drivers();
+
+    // SQLite in-memory databases are per-connection; a pool with >1 connection
+    // would give each checkout its own empty database.  Cap to 1 for :memory: URLs.
+    let max_conns: u32 = if url.contains(":memory:") { 1 } else { 5 };
+
+    let pool = AnyPoolOptions::new()
+        .max_connections(max_conns)
+        .connect(url)
         .await?;
     Ok(pool)
 }
 
-pub async fn migrate(pool: &Db) -> anyhow::Result<()> {
-    sqlx::migrate!("./migrations").run(pool).await?;
+pub async fn migrate(pool: &Db, url: &str) -> anyhow::Result<()> {
+    if url.starts_with("postgres") {
+        // PostgreSQL: use migrations_pg directory.
+        // MIGRATIONS_PG_PATH env var overrides the compile-time default (useful in Docker).
+        let path = std::env::var("MIGRATIONS_PG_PATH")
+            .unwrap_or_else(|_| concat!(env!("CARGO_MANIFEST_DIR"), "/migrations_pg").to_string());
+        sqlx::migrate::Migrator::new(std::path::Path::new(&path))
+            .await?
+            .run(pool)
+            .await?;
+    } else {
+        // SQLite: use compile-time embedded migrations.
+        sqlx::migrate!("./migrations").run(pool).await?;
+    }
     Ok(())
 }

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -26,7 +26,7 @@ async fn main() -> Result<()> {
     tracing::info!(host = %config.server.host, port = %config.server.port, "starting ghostkey-server");
 
     let pool = db::connect(&config.database.url).await?;
-    db::migrate(&pool).await?;
+    db::migrate(&pool, &config.database.url).await?;
 
     let app = routes::build(pool, config.clone());
 

--- a/server/tests/helpers.rs
+++ b/server/tests/helpers.rs
@@ -55,7 +55,9 @@ pub async fn test_server_and_db_with_bundler(
     };
 
     let pool = db::connect(&config.database.url).await.expect("test db");
-    db::migrate(&pool).await.expect("test migrations");
+    db::migrate(&pool, &config.database.url)
+        .await
+        .expect("test migrations");
     let app = routes::build(pool.clone(), config);
     (TestServer::new(app).expect("test server"), pool)
 }


### PR DESCRIPTION
## Summary
- `sqlx` gains `postgres` and `any` features; `Db` type is now `AnyPool`
- `db::connect()` installs both SQLite and PostgreSQL drivers at startup
- `db::migrate()` dispatches to the correct migration set based on the URL scheme:
  - `postgres://…` → `migrations_pg/` (PostgreSQL-compatible SQL with `BIGINT` timestamps)
  - `sqlite://…` → `migrations/` (compile-time embedded, unchanged)
- `migrations_pg/` mirrors `migrations/` but replaces `strftime('%s','now')` with `EXTRACT(EPOCH FROM NOW())::BIGINT`
- SQLite `:memory:` pools capped at 1 connection to avoid per-connection split-brain in tests
- Set `DATABASE_URL=postgres://user:pass@host/db` to switch; `MIGRATIONS_PG_PATH` overrides the migration directory for Docker deployments

## Test plan
- [ ] All existing Rust tests pass with SQLite (no regression)
- [ ] `DATABASE_URL=postgres://localhost/ghostkey cargo run` starts and migrates a local PG database
- [ ] All endpoints function correctly against PostgreSQL

🤖 Generated with [Claude Code](https://claude.com/claude-code)