### PR TITLE
fix(release): stop swallowing real npm publish failures

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,7 +116,17 @@ jobs:
         run: npm run build
 
       - name: Publish
-        run: npm publish --access public || echo "Version already published, skipping."
+        shell: bash
+        run: |
+          set -o pipefail
+          if npm publish --access public 2>&1 | tee /tmp/npm-publish.log; then
+            echo "Published."
+          elif grep -qi "cannot publish over" /tmp/npm-publish.log; then
+            echo "Version already published, skipping."
+          else
+            echo "::error::npm publish failed for a reason other than 'already published' (see log above) — check NPM_TOKEN validity/scope before re-running."
+            exit 1
+          fi
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,17 @@ _Nothing unreleased yet._
 
 ---
 
+## [1.0.2] — 2026-08-17 — Release pipeline fix
+
+### Fixed
+- The `v1.0.1` tag's `npm-publish` job actually failed (`npm error E404 — '@ghostkey/sdk@1.0.1' is not in this registry`, almost certainly `NPM_TOKEN` expiring — it hadn't been rotated since the `v1.0.0` release ~5 months earlier). The job still reported green because `npm publish --access public || echo "Version already published, skipping."` swallows *any* publish failure, not just the "already published" case it was written for.
+- `.github/workflows/release.yml`: the `Publish` step now only treats the specific "cannot publish over previously published versions" npm error as non-fatal; every other failure (bad/expired token, network, registry error) now fails the job instead of being silently swallowed.
+- No SDK code changes — version bumped only because `1.0.1` is tied to a tag/release that already exists from the failed attempt; reusing it would mean force-moving a published tag.
+
+**Before tagging `v1.0.2`: `NPM_TOKEN` must be rotated** — generate a new token on npmjs.com and update the `NPM_TOKEN` GitHub Actions secret. This step requires npm account access and isn't something CI or an agent can do.
+
+---
+
 ## [1.0.1] — 2026-08-17 — SDK npm listing fix
 
 ### Fixed

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ghostkey/sdk",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "GhostKey wallet abstraction SDK",
   "license": "MIT",
   "author": "GhostKey",


### PR DESCRIPTION
## Summary
- `v1.0.1`'s `npm-publish` job actually failed (`E404`, `@ghostkey/sdk@1.0.1` never hit the registry) but reported green — `npm publish || echo "already published"` swallows *any* failure, not just the harmless re-run case it was meant for. Root cause: `NPM_TOKEN` almost certainly expired (created 2026-03-26, never rotated since).
- `release.yml`: only swallow the specific "cannot publish over previously published versions" npm error now; anything else (bad token, network, registry error) fails the job for real.
- `sdk/package.json`: bump to `1.0.2`. No code changes — reusing the `1.0.1` tag would mean force-moving an already-pushed tag/release.
- CHANGELOG documents what happened.

## Blocking manual step (not part of this PR)
`NPM_TOKEN` must be rotated on npmjs.com and the GitHub Actions secret updated before tagging `v1.0.2` — needs npm account access.

## Test plan
- [x] `release.yml` validated as well-formed YAML
- [x] `sdk/package.json` validated as well-formed JSON
- [x] `cargo fmt --check` pre-commit hook passed
- [ ] CI green
- [ ] After NPM_TOKEN is rotated and this merges to `main`, tag `v1.0.2` to re-attempt the publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)