### PR TITLE
chore: promote dev → main — release pipeline fix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,7 +116,17 @@ jobs:
         run: npm run build
 
       - name: Publish
-        run: npm publish --access public || echo "Version already published, skipping."
+        shell: bash
+        run: |
+          set -o pipefail
+          if npm publish --access public 2>&1 | tee /tmp/npm-publish.log; then
+            echo "Published."
+          elif grep -qi "cannot publish over" /tmp/npm-publish.log; then
+            echo "Version already published, skipping."
+          else
+            echo "::error::npm publish failed for a reason other than 'already published' (see log above) — check NPM_TOKEN validity/scope before re-running."
+            exit 1
+          fi
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,17 @@ _Nothing unreleased yet._
 
 ---
 
+## [1.0.2] — 2026-08-17 — Release pipeline fix
+
+### Fixed
+- The `v1.0.1` tag's `npm-publish` job actually failed (`npm error E404 — '@ghostkey/sdk@1.0.1' is not in this registry`, almost certainly `NPM_TOKEN` expiring — it hadn't been rotated since the `v1.0.0` release ~5 months earlier). The job still reported green because `npm publish --access public || echo "Version already published, skipping."` swallows *any* publish failure, not just the "already published" case it was written for.
+- `.github/workflows/release.yml`: the `Publish` step now only treats the specific "cannot publish over previously published versions" npm error as non-fatal; every other failure (bad/expired token, network, registry error) now fails the job instead of being silently swallowed.
+- No SDK code changes — version bumped only because `1.0.1` is tied to a tag/release that already exists from the failed attempt; reusing it would mean force-moving a published tag.
+
+**Before tagging `v1.0.2`: `NPM_TOKEN` must be rotated** — generate a new token on npmjs.com and update the `NPM_TOKEN` GitHub Actions secret. This step requires npm account access and isn't something CI or an agent can do.
+
+---
+
 ## [1.0.1] — 2026-08-17 — SDK npm listing fix
 
 ### Fixed

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ghostkey/sdk",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "GhostKey wallet abstraction SDK",
   "license": "MIT",
   "author": "GhostKey",


### PR DESCRIPTION
## Summary
Promotes `dev` → `main`. 2 commits:

- fix(release): stop swallowing real npm publish failures (#130) — the `v1.0.1` npm publish silently failed (expired `NPM_TOKEN`) because `|| echo "already published"` masked the real error; now only that specific case is treated as non-fatal
- SDK bumped to `1.0.2` (no code changes — `1.0.1`'s tag/release already exist from the failed attempt)

`NPM_TOKEN` has been rotated (new granular token, read+write on `@ghostkey/sdk`, expires 2026-11-15) and the GitHub secret updated.

## Test plan
- [x] CI green on #130 before merging to `dev`
- [ ] CI green on this PR
- [ ] Tag `v1.0.2` after merge to complete the npm publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)