### PR TITLE
feat(auth): implement SIWE wallet login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ Updated on every merge to `main`.
 
 ### Added
 - `story/` — interactive, scroll-driven explainer for why GhostKey uses scoped session keys instead of raw wallet keys. Five chapters: the failure mode of an all-or-nothing key, the smart-account/session-key model, an interactive session-key builder, a real client-side key-generation + SHA-256 hashing demo (WebCrypto, no network calls), and a "try to break it" demo that mirrors the real `intent_out_of_scope` / `value_exceeds_session_limit` server error codes. Fully simulated — no wallet, testnet funds, or running server required.
+- **SIWE wallet login** — `method: "wallet"` on `POST /auth/login` is now fully implemented (the `AuthMethod::Wallet` enum variant existed since Phase 1 but was never wired up; the endpoint just hashed whatever string was sent as `credential`, with no signature verification at all).
+  - `GET /auth/wallet/nonce` — single-use, 5-minute nonce, rate-limited per IP, consumed atomically on verification (no separate `used` flag / read-then-write race).
+  - `POST /auth/login` (method = wallet): parses `credential` as a SIWE (EIP-4361) message via the `siwe` crate, checks the nonce was actually issued by this server and not already used, checks the message's `domain` matches the new `server.siwe_domain` config (phishing/cross-site relay protection), checks the message is currently valid (`issued_at`/`expiration`/`not_before`), checks `chain_id` against this deployment's enabled chains, and recovers the signer from `signature` to confirm it matches the address the message claims. A wallet is identified by its lowercased address, same as email is identified by the email address.
+  - New migration `0005_siwe_nonces` (sqlite + postgres).
+  - SDK: `useWalletLogin()` hook — requests accounts from `window.ethereum`, fetches a nonce, builds the SIWE message, requests `personal_sign`, and calls the existing `useLogin` flow. Composes `useLogin` rather than duplicating its state. `buildSiweMessage()` / `toPersonalSignHex()` exported for advanced use.
+  - Server: 7 new integration tests covering the actual security properties — wrong signer rejected, unknown/replayed nonce rejected, wrong domain rejected, no signature material leaked into responses. SDK: unit tests for the hook and the message builder.
 
 ---
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,6 +185,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -365,6 +371,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -462,12 +480,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der",
+ "digest",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest",
+ "ff",
+ "generic-array",
+ "group",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sec1",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -506,6 +557,16 @@ dependencies = [
  "concurrent-queue",
  "parking",
  "pin-project-lite",
+]
+
+[[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
 ]
 
 [[package]]
@@ -667,6 +728,7 @@ checksum = "4bb6743198531e02858aeaea5398fcc883e71851fcbcb5a2f773e2fb6cb1edf2"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -710,11 +772,14 @@ dependencies = [
  "figment",
  "hex",
  "jsonwebtoken",
+ "k256",
  "regex",
  "reqwest",
  "serde",
  "serde_json",
  "sha2",
+ "sha3",
+ "siwe",
  "sqlx",
  "thiserror 2.0.18",
  "tokio",
@@ -725,6 +790,17 @@ dependencies = [
  "utoipa",
  "uuid",
  "wiremock",
+]
+
+[[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core 0.6.4",
+ "subtle",
 ]
 
 [[package]]
@@ -1137,6 +1213,29 @@ dependencies = [
  "serde",
  "serde_json",
  "simple_asn1",
+]
+
+[[package]]
+name = "k256"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6e3919bbaa2945715f0bb6d3934a173d1e9a59ac23767fbaaef277265a7411b"
+dependencies = [
+ "cfg-if",
+ "ecdsa",
+ "elliptic-curve",
+ "once_cell",
+ "sha2",
+ "signature",
+]
+
+[[package]]
+name = "keccak"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
+dependencies = [
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -1795,6 +1894,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac",
+ "subtle",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1904,6 +2013,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "pkcs8",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "semver"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2007,6 +2130,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha3"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77fd7028345d415a4034cf8777cd4f8ab1851274233b45f84e3d955502d93874"
+dependencies = [
+ "digest",
+ "keccak",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2050,6 +2183,22 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
+name = "siwe"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95bdefc0eedf06440b27092fbfe33f2cb493ad6a3423aa12cfe7f2aac44bd618"
+dependencies = [
+ "hex",
+ "http 1.4.0",
+ "iri-string",
+ "k256",
+ "rand 0.8.5",
+ "sha3",
+ "thiserror 1.0.69",
  "time",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 
 # auth
 jsonwebtoken = "9"
+siwe = "0.6"
 
 # crypto / chain — added by Backend Engineer when implementing chain adapter (Phase 1)
 # alloy = { version = "1", features = ["providers", "rpc-types", "serde", "signers"] }

--- a/config.toml.example
+++ b/config.toml.example
@@ -23,6 +23,10 @@ port = 8080
 cors_origins = ["http://localhost:3000"]
 # Log format: "pretty" for local dev, "json" for production / log aggregation.
 log_format = "pretty"
+# Expected `domain` field on incoming SIWE (Sign-In with Ethereum) messages —
+# must match your frontend's origin (not this API's host). A signed message
+# for any other domain is rejected.
+siwe_domain = "localhost:3000"
 
 [database]
 url = "sqlite:./db/ghostkey.db"   # SQLite path; sqlite::memory: for ephemeral

--- a/docs/api/endpoints.md
+++ b/docs/api/endpoints.md
@@ -1,4 +1,4 @@
-KAuthority order for conflict resolution:# GhostKey API Reference
+# GhostKey API Reference
 
 Base URL: configured via `GHOSTKEY__SERVER__HOST` and `GHOSTKEY__SERVER__PORT` (default `http://localhost:8080`)
 
@@ -10,9 +10,9 @@ All endpoints return JSON. Authenticated endpoints require `Authorization: Beare
 
 ### POST /auth/login
 
-Authenticate a user and receive a JWT.
+Authenticate a user and receive a JWT. Two methods are supported.
 
-**Request**
+**Request — email**
 
 ```json
 {
@@ -21,10 +21,29 @@ Authenticate a user and receive a JWT.
 }
 ```
 
+**Request — wallet (SIWE / EIP-4361)**
+
+```json
+{
+  "method": "wallet",
+  "credential": "localhost:3000 wants you to sign in with your Ethereum account:\n0x...\n\nSign in to GhostKey\n\nURI: http://localhost:3000\nVersion: 1\nChain ID: 84532\nNonce: <from GET /auth/wallet/nonce>\nIssued At: 2026-03-26T14:00:00.000Z",
+  "signature": "0x..."
+}
+```
+
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `method` | string | yes | Authentication method. Currently: `"email"` |
-| `credential` | string | yes | Email address |
+| `method` | string | yes | `"email"` or `"wallet"` |
+| `credential` | string | yes | Email address (`email`) or the full SIWE message text (`wallet`) |
+| `signature` | string | wallet only | Hex-encoded 65-byte ECDSA signature over `credential` |
+
+Wallet login gets its nonce from `GET /auth/wallet/nonce` first — see below. The
+signer address is recovered from the signature and must match the address in
+the message; the message's `domain` must match this server's configured
+`siwe_domain`; the nonce must be one this server issued and not yet used. A
+user is identified by their (lowercased) wallet address, same as email is
+identified by the email address — logging in again with the same wallet
+returns the same `user_id`.
 
 **Response — 201 Created**
 
@@ -40,7 +59,28 @@ Authenticate a user and receive a JWT.
 
 | Status | `error` | Description |
 |--------|---------|-------------|
-| 400 | `invalid_request` | Missing or malformed fields |
+| 400 | `bad_request` | Missing/malformed fields, missing signature, invalid SIWE message, unsupported chain |
+| 401 | `unauthorized` | Signature doesn't match the claimed address, or nonce is invalid/expired/already used, or domain mismatch |
+| 429 | `rate_limited` | Rate limit exceeded (10/60s per IP) |
+
+---
+
+### GET /auth/wallet/nonce
+
+Issue a single-use nonce for SIWE login. Embed the returned value as the
+`Nonce:` field of the message the wallet signs. Expires in 5 minutes;
+consumed on first use — cannot be replayed.
+
+**Response — 200 OK**
+
+```json
+{ "nonce": "3sK9dLp2mQxV8..." }
+```
+
+**Errors**
+
+| Status | `error` | Description |
+|--------|---------|-------------|
 | 429 | `rate_limited` | Rate limit exceeded (10/60s per IP) |
 
 ---

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -64,6 +64,24 @@ export function LoginButton() {
 }
 ```
 
+**Or sign in with a wallet** (MetaMask or any EIP-1193 provider) via SIWE — no email required:
+
+```tsx
+import { useWalletLogin } from '@ghostkey/sdk'
+
+export function ConnectWalletButton() {
+  const { connect, status, address } = useWalletLogin()
+
+  return (
+    <button onClick={connect} disabled={status === 'loading'}>
+      {status === 'authenticated' ? `Connected: ${address}` : 'Connect Wallet'}
+    </button>
+  )
+}
+```
+
+Requires `server.siwe_domain` in `config.toml` to match your frontend's origin. See [SDK Hook Reference](./sdk/hooks.md#usewalletlogin) and [API Reference](./api/endpoints.md).
+
 ---
 
 ## 4. Create a smart account

--- a/docs/sdk/hooks.md
+++ b/docs/sdk/hooks.md
@@ -65,6 +65,60 @@ logout()
 
 ---
 
+## useWalletLogin
+
+Sign in with an injected wallet (MetaMask or any EIP-1193 provider) via
+SIWE (Sign-In with Ethereum, EIP-4361), instead of email. Composes
+`useLogin` internally — `status`/`userId`/session handling are identical
+once the wallet has signed in.
+
+```tsx
+const {
+  connect,   // () => Promise<void>
+  status,    // same LoginStatus as useLogin
+  userId,    // string | null
+  address,   // string | null — the connecting wallet's address
+  error,     // { code: string; message: string } | null
+} = useWalletLogin()
+```
+
+### `connect()`
+
+1. Requests accounts from `window.ethereum` (`eth_requestAccounts`)
+2. Calls `GET /auth/wallet/nonce` for a single-use nonce
+3. Builds a SIWE message and asks the wallet to sign it (`personal_sign`) —
+   the private key never leaves the wallet extension; only a signature is
+   requested
+4. Calls `POST /auth/login` with `method: "wallet"`
+
+```tsx
+import { useWalletLogin } from '@ghostkey/sdk'
+
+function ConnectButton() {
+  const { connect, status, address, error } = useWalletLogin()
+
+  if (status === 'authenticated') return <p>Connected: {address}</p>
+
+  return (
+    <button onClick={connect} disabled={status === 'loading'}>
+      {error ? `Retry (${error.code})` : 'Connect Wallet'}
+    </button>
+  )
+}
+```
+
+No wallet-specific config is required — `connect()` reads `chainId` from
+`<GhostKeyProvider config={{ chainId }}>` and `domain`/`uri` from
+`window.location`. Requires `siwe_domain` on the server to match your
+frontend's origin (see [API reference](../api/endpoints.md)).
+
+### `wallet_not_found` error
+
+Returned when `window.ethereum` doesn't exist, the wallet returns no
+accounts, or the user rejects the connection/signature prompt.
+
+---
+
 ## useAccount
 
 **SPEC-101** — Create and fetch smart account state.
@@ -306,6 +360,8 @@ await initiateRecovery('0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045')
 |------|--------|-------------|
 | `not_authenticated` | hooks | User is not logged in |
 | `invalid_token` | useLogin | Login credentials invalid |
+| `wallet_not_found` | useWalletLogin | No injected wallet, no accounts, or the user rejected the prompt |
+| `invalid_signature` | useWalletLogin | SIWE signature doesn't match the claimed address, or nonce/domain check failed |
 | `session_expired` | useSendIntent | Session key has expired |
 | `intent_out_of_scope` | useSendIntent | Target or selector not allowed |
 | `value_exceeds_session_limit` | useSendIntent | Value exceeds max |

--- a/sdk/package-lock.json
+++ b/sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ghostkey/sdk",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ghostkey/sdk",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
         "permissionless": "^0.3.4",

--- a/sdk/src/client.ts
+++ b/sdk/src/client.ts
@@ -137,10 +137,17 @@ export class GhostKeyClient {
 
   // ── API methods ────────────────────────────────────────────────────────────
 
-  async login(method: string, credential: string): Promise<ApiResult<AuthResponse>> {
-    const res = await this.request<RawAuth>('POST', '/auth/login', { method, credential })
+  async login(method: string, credential: string, signature?: string): Promise<ApiResult<AuthResponse>> {
+    const res = await this.request<RawAuth>('POST', '/auth/login', { method, credential, signature })
     if (res.error) return res
     return { data: this.mapAuth(res.data), error: null }
+  }
+
+  /** GET /auth/wallet/nonce — single-use SIWE nonce, expires in 5 minutes. */
+  async fetchWalletNonce(): Promise<ApiResult<string>> {
+    const res = await this.request<{ nonce: string }>('GET', '/auth/wallet/nonce')
+    if (res.error) return res
+    return { data: res.data.nonce, error: null }
   }
 
   async refresh(token: string): Promise<ApiResult<AuthResponse>> {

--- a/sdk/src/hooks/useLogin.ts
+++ b/sdk/src/hooks/useLogin.ts
@@ -6,7 +6,7 @@ import { useGhostKey } from '../provider.js'
 export type LoginStatus = 'idle' | 'loading' | 'authenticated' | 'error'
 
 export interface UseLoginReturn {
-  login: (method: AuthMethod, credential: string) => Promise<void>
+  login: (method: AuthMethod, credential: string, signature?: string) => Promise<void>
   logout: () => void
   status: LoginStatus
   userId: string | null
@@ -19,13 +19,14 @@ export function useLogin(): UseLoginReturn {
   const [userId, setUserId] = useState<string | null>(null)
   const [error, setError] = useState<GhostKeyError | null>(null)
 
-  async function login(method: AuthMethod, credential: string): Promise<void> {
+  async function login(method: AuthMethod, credential: string, signature?: string): Promise<void> {
     setStatus('loading')
     setError(null)
 
-    // SPEC-100: private key must never be sent to any network request
-    // Credential here is email/wallet address — not a private key
-    const result = await client.login(method, credential)
+    // SPEC-100: private key must never be sent to any network request.
+    // Credential is email, or (method = wallet) the SIWE message text —
+    // signature is a wallet signature over that text, never key material.
+    const result = await client.login(method, credential, signature)
 
     if (result.error) {
       setStatus('error')

--- a/sdk/src/hooks/useWalletLogin.ts
+++ b/sdk/src/hooks/useWalletLogin.ts
@@ -1,0 +1,83 @@
+// useWalletLogin — SIWE (Sign-In with Ethereum) login via an injected wallet
+// (MetaMask or any EIP-1193 provider). Composes useLogin rather than
+// duplicating its state: the SIWE-specific part is only getting a nonce,
+// building the message, and asking the wallet to sign it — the actual
+// login/session handling is identical to email login from here on.
+import { useState } from 'react'
+import type { GhostKeyError } from '../types.js'
+import { useGhostKey } from '../provider.js'
+import { useLogin, type LoginStatus } from './useLogin.js'
+import { buildSiweMessage, toPersonalSignHex } from '../siwe.js'
+
+interface EthereumProvider {
+  request: (args: { method: string; params?: unknown[] }) => Promise<unknown>
+}
+
+function getEthereumProvider(): EthereumProvider | null {
+  const eth = (globalThis as { ethereum?: EthereumProvider }).ethereum
+  return eth ?? null
+}
+
+export interface UseWalletLoginReturn {
+  /** Prompts the wallet for accounts, requests a nonce, and signs a SIWE message. */
+  connect: () => Promise<void>
+  status: LoginStatus
+  userId: string | null
+  /** The connecting wallet's address, set as soon as the wallet returns it. */
+  address: string | null
+  error: GhostKeyError | null
+}
+
+export function useWalletLogin(): UseWalletLoginReturn {
+  const { client, config } = useGhostKey()
+  const { login, status, userId, error: loginError } = useLogin()
+  const [address, setAddress] = useState<string | null>(null)
+  const [connectError, setConnectError] = useState<GhostKeyError | null>(null)
+
+  async function connect(): Promise<void> {
+    setConnectError(null)
+
+    const eth = getEthereumProvider()
+    if (!eth) {
+      setConnectError({ code: 'wallet_not_found', message: 'No injected wallet (e.g. MetaMask) found' })
+      return
+    }
+
+    try {
+      const accounts = (await eth.request({ method: 'eth_requestAccounts' })) as string[]
+      const walletAddress = accounts[0]
+      if (!walletAddress) {
+        setConnectError({ code: 'wallet_not_found', message: 'Wallet returned no accounts' })
+        return
+      }
+      setAddress(walletAddress)
+
+      const nonceResult = await client.fetchWalletNonce()
+      if (nonceResult.error) {
+        setConnectError(nonceResult.error)
+        return
+      }
+
+      // SPEC-100: no private key or key material is ever touched here —
+      // the wallet extension holds the key; we only ask it to sign text.
+      const message = buildSiweMessage({
+        domain: window.location.host,
+        address: walletAddress as `0x${string}`,
+        uri: window.location.origin,
+        chainId: config.chainId,
+        nonce: nonceResult.data,
+      })
+
+      const signature = (await eth.request({
+        method: 'personal_sign',
+        params: [toPersonalSignHex(message), walletAddress],
+      })) as string
+
+      await login('wallet', message, signature)
+    } catch {
+      setConnectError({ code: 'wallet_not_found', message: 'Wallet connection was rejected or failed' })
+    }
+  }
+
+  return { connect, status, userId, address, error: connectError ?? loginError }
+}

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -1,6 +1,11 @@
 // @ghostkey/sdk — public API surface
 export { GhostKeyProvider } from './provider.js'
 export { useLogin } from './hooks/useLogin.js'
+export type { UseLoginReturn, LoginStatus } from './hooks/useLogin.js'
+export { useWalletLogin } from './hooks/useWalletLogin.js'
+export type { UseWalletLoginReturn } from './hooks/useWalletLogin.js'
+export { buildSiweMessage, toPersonalSignHex } from './siwe.js'
+export type { BuildSiweMessageParams } from './siwe.js'
 export { useAccount } from './hooks/useAccount.js'
 export { useSendIntent } from './hooks/useSendIntent.js'
 export { useSessionKey } from './hooks/useSessionKey.js'

--- a/sdk/src/siwe.ts
+++ b/sdk/src/siwe.ts
@@ -1,0 +1,56 @@
+// siwe.ts — EIP-4361 (Sign-In with Ethereum) message construction.
+//
+// Builds the exact message text the server's `siwe` crate (spruceid/siwe-rs)
+// re-parses on verification. The layout below is not a loose paraphrase of
+// the spec — it matches that crate's `Display for Message` impl line for
+// line, since the server round-trips this text through its own parser.
+
+export interface BuildSiweMessageParams {
+  /** Frontend origin the wallet is signing in to — e.g. `window.location.host`. */
+  domain: string
+  /** EIP-55 checksummed address (viem's `getAddress()` already returns this). */
+  address: `0x${string}`
+  /** Frontend origin as a full URI — e.g. `window.location.origin`. */
+  uri: string
+  /** Chain ID the session is bound to (84532 = Base Sepolia, 8453 = Base, 42161 = Arbitrum, 1 = Ethereum). */
+  chainId: number
+  /** Single-use nonce from `GET /auth/wallet/nonce`. */
+  nonce: string
+  /** Human-readable line shown in the wallet's signing prompt. */
+  statement?: string
+  /** Defaults to now. */
+  issuedAt?: Date
+}
+
+export function buildSiweMessage(params: BuildSiweMessageParams): string {
+  const {
+    domain,
+    address,
+    uri,
+    chainId,
+    nonce,
+    statement = 'Sign in to GhostKey',
+    issuedAt = new Date(),
+  } = params
+
+  return [
+    `${domain} wants you to sign in with your Ethereum account:`,
+    address,
+    '',
+    statement,
+    '',
+    `URI: ${uri}`,
+    'Version: 1',
+    `Chain ID: ${chainId}`,
+    `Nonce: ${nonce}`,
+    `Issued At: ${issuedAt.toISOString()}`,
+  ].join('\n')
+}
+
+/** Hex-encodes a UTF-8 string for `personal_sign`'s message parameter (EIP-1193). */
+export function toPersonalSignHex(message: string): `0x${string}` {
+  const bytes = new TextEncoder().encode(message)
+  let hex = '0x'
+  for (const b of bytes) hex += b.toString(16).padStart(2, '0')
+  return hex as `0x${string}`
+}

--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -86,6 +86,8 @@ export type GhostKeyErrorCode =
   | 'session_expired'
   | 'intent_out_of_scope'
   | 'rate_limited'
+  | 'wallet_not_found'
+  | 'invalid_signature'
   | 'unknown'
 
 export interface GhostKeyError {

--- a/sdk/tests/hooks.test.ts
+++ b/sdk/tests/hooks.test.ts
@@ -1,8 +1,9 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { renderHook, act } from '@testing-library/react'
 import React from 'react'
 import { GhostKeyProvider } from '../src/provider.js'
 import { useLogin } from '../src/hooks/useLogin.js'
+import { useWalletLogin } from '../src/hooks/useWalletLogin.js'
 import { useAccount } from '../src/hooks/useAccount.js'
 import { useSessionKey } from '../src/hooks/useSessionKey.js'
 import { useSendIntent } from '../src/hooks/useSendIntent.js'
@@ -53,6 +54,7 @@ function mockClient(overrides: Partial<GhostKeyClient> = {}): GhostKeyClient {
     setToken: vi.fn(),
     clearToken: vi.fn(),
     login: vi.fn(),
+    fetchWalletNonce: vi.fn(),
     refresh: vi.fn(),
     createAccount: vi.fn(),
     getAccount: vi.fn(),
@@ -160,6 +162,110 @@ describe('useLogin', () => {
     expect(result.current.status).toBe('idle')
     expect(result.current.userId).toBeNull()
     expect(client.clearToken).toHaveBeenCalled()
+  })
+})
+
+// ── useWalletLogin ────────────────────────────────────────────────────────────
+
+function mockEthereum(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    request: vi.fn(async ({ method }: { method: string }) => {
+      if (method === 'eth_requestAccounts') return ['0xAbC1230000000000000000000000000000dEaD']
+      if (method === 'personal_sign') return '0xsignature'
+      throw new Error(`unexpected method: ${method}`)
+    }),
+    ...overrides,
+  }
+}
+
+describe('useWalletLogin', () => {
+  afterEach(() => {
+    // @ts-expect-error test-only cleanup of a global we stub per test
+    delete globalThis.ethereum
+  })
+
+  it('reports wallet_not_found when no injected provider exists', async () => {
+    const client = mockClient()
+    const { result } = renderHook(() => useWalletLogin(), { wrapper: wrapper(client) })
+
+    await act(async () => {
+      await result.current.connect()
+    })
+
+    expect(result.current.error?.code).toBe('wallet_not_found')
+    expect(result.current.address).toBeNull()
+  })
+
+  it('requests accounts, fetches a nonce, signs, and logs in', async () => {
+    const eth = mockEthereum()
+    // @ts-expect-error test-only global stub
+    globalThis.ethereum = eth
+
+    const client = mockClient({
+      fetchWalletNonce: vi.fn().mockResolvedValue({ data: 'test-nonce-123', error: null }),
+      login: vi.fn().mockResolvedValue({
+        data: { userId: 'user-wallet-1', token: 'tok', expiresAt: '2099-01-01' },
+        error: null,
+      }),
+    })
+    const { result } = renderHook(() => useWalletLogin(), { wrapper: wrapper(client) })
+
+    await act(async () => {
+      await result.current.connect()
+    })
+
+    expect(result.current.address).toBe('0xAbC1230000000000000000000000000000dEaD')
+    expect(client.fetchWalletNonce).toHaveBeenCalled()
+
+    // SPEC-100: only a signature request goes to the wallet — never key material
+    expect(eth.request).toHaveBeenCalledWith(
+      expect.objectContaining({ method: 'personal_sign' }),
+    )
+
+    // login() must receive the SIWE message (containing the nonce) and the
+    // wallet's signature — never a raw private key.
+    const loginCall = (client.login as ReturnType<typeof vi.fn>).mock.calls[0]
+    expect(loginCall[0]).toBe('wallet')
+    expect(loginCall[1]).toContain('test-nonce-123')
+    expect(loginCall[2]).toBe('0xsignature')
+
+    expect(result.current.status).toBe('authenticated')
+    expect(result.current.userId).toBe('user-wallet-1')
+  })
+
+  it('surfaces the server error when the nonce request fails', async () => {
+    // @ts-expect-error test-only global stub
+    globalThis.ethereum = mockEthereum()
+
+    const client = mockClient({
+      fetchWalletNonce: vi
+        .fn()
+        .mockResolvedValue({ data: null, error: { code: 'rate_limited', message: 'slow down' } }),
+    })
+    const { result } = renderHook(() => useWalletLogin(), { wrapper: wrapper(client) })
+
+    await act(async () => {
+      await result.current.connect()
+    })
+
+    expect(result.current.error?.code).toBe('rate_limited')
+    expect(client.login).not.toHaveBeenCalled()
+  })
+
+  it('sets wallet_not_found if the user rejects the wallet prompt', async () => {
+    // @ts-expect-error test-only global stub
+    globalThis.ethereum = {
+      request: vi.fn().mockRejectedValue(new Error('User rejected the request')),
+    }
+
+    const client = mockClient()
+    const { result } = renderHook(() => useWalletLogin(), { wrapper: wrapper(client) })
+
+    await act(async () => {
+      await result.current.connect()
+    })
+
+    expect(result.current.error?.code).toBe('wallet_not_found')
   })
 })
 

--- a/sdk/tests/siwe.test.ts
+++ b/sdk/tests/siwe.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest'
+import { buildSiweMessage, toPersonalSignHex } from '../src/siwe.js'
+
+describe('buildSiweMessage', () => {
+  it('produces the exact EIP-4361 layout the server re-parses', () => {
+    const message = buildSiweMessage({
+      domain: 'localhost:3000',
+      address: '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045',
+      uri: 'http://localhost:3000',
+      chainId: 84532,
+      nonce: 'abc123XYZ',
+      statement: 'Sign in to GhostKey',
+      issuedAt: new Date('2026-01-01T00:00:00.000Z'),
+    })
+
+    expect(message).toBe(
+      [
+        'localhost:3000 wants you to sign in with your Ethereum account:',
+        '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045',
+        '',
+        'Sign in to GhostKey',
+        '',
+        'URI: http://localhost:3000',
+        'Version: 1',
+        'Chain ID: 84532',
+        'Nonce: abc123XYZ',
+        'Issued At: 2026-01-01T00:00:00.000Z',
+      ].join('\n'),
+    )
+  })
+
+  it('defaults the statement and issuedAt when omitted', () => {
+    const message = buildSiweMessage({
+      domain: 'localhost:3000',
+      address: '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045',
+      uri: 'http://localhost:3000',
+      chainId: 8453,
+      nonce: 'n',
+    })
+
+    expect(message).toContain('Sign in to GhostKey')
+    expect(message).toMatch(/Issued At: \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/)
+  })
+})
+
+describe('toPersonalSignHex', () => {
+  it('hex-encodes UTF-8 bytes with a 0x prefix', () => {
+    expect(toPersonalSignHex('hi')).toBe('0x6869')
+  })
+})

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -27,6 +27,7 @@ tracing-subscriber.workspace = true
 jsonwebtoken.workspace = true
 uuid.workspace = true
 chrono.workspace = true
+siwe.workspace = true
 
 # hashing
 sha2 = "0.10"
@@ -48,3 +49,7 @@ tokio = { version = "1", features = ["full"] }
 axum-test = "15"
 regex = "1"
 wiremock = "0.6"
+
+# signing test SIWE messages (versions match what `siwe` already pulls in)
+k256 = "0.13"
+sha3 = "0.10"

--- a/server/migrations/0005_siwe_nonces.sql
+++ b/server/migrations/0005_siwe_nonces.sql
@@ -1,0 +1,11 @@
+-- SIWE (Sign-In with Ethereum, EIP-4361) nonces.
+-- Single-use: consumed via DELETE on verification, not a `used` flag —
+-- avoids a read-then-write race between checking and marking a nonce spent.
+
+CREATE TABLE IF NOT EXISTS siwe_nonces (
+    nonce      TEXT    PRIMARY KEY,
+    expires_at INTEGER NOT NULL,      -- unix epoch — nonces are short-lived (5 min)
+    created_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_siwe_nonces_expires ON siwe_nonces(expires_at);

--- a/server/migrations_pg/0005_siwe_nonces.sql
+++ b/server/migrations_pg/0005_siwe_nonces.sql
@@ -1,0 +1,11 @@
+-- SIWE (Sign-In with Ethereum, EIP-4361) nonces — PostgreSQL
+-- Single-use: consumed via DELETE on verification, not a `used` flag —
+-- avoids a read-then-write race between checking and marking a nonce spent.
+
+CREATE TABLE IF NOT EXISTS siwe_nonces (
+    nonce      TEXT    PRIMARY KEY,
+    expires_at BIGINT  NOT NULL,
+    created_at BIGINT  NOT NULL DEFAULT EXTRACT(EPOCH FROM NOW())::BIGINT
+);
+
+CREATE INDEX IF NOT EXISTS idx_siwe_nonces_expires ON siwe_nonces(expires_at);

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -24,6 +24,11 @@ pub struct ServerConfig {
     /// Log format: "pretty" (default) or "json" (for production/structured logging).
     #[serde(default = "default_log_format")]
     pub log_format: String,
+    /// Expected `domain` field on incoming SIWE (EIP-4361) sign-in messages —
+    /// must match the frontend origin, not the API host. Rejects messages
+    /// signed for a different site (phishing/relay protection).
+    #[serde(default = "default_siwe_domain")]
+    pub siwe_domain: String,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -76,6 +81,9 @@ fn default_cors_origins() -> Vec<String> {
 }
 fn default_log_format() -> String {
     "pretty".to_string()
+}
+fn default_siwe_domain() -> String {
+    "localhost:3000".to_string()
 }
 
 fn default_host() -> String {

--- a/server/src/models/user.rs
+++ b/server/src/models/user.rs
@@ -25,7 +25,12 @@ impl DbUser {
 #[derive(Debug, Deserialize, utoipa::ToSchema)]
 pub struct LoginRequest {
     pub method: AuthMethod,
+    /// Email address (method = email) or the full SIWE message text (method = wallet).
     pub credential: String,
+    /// Required when method = wallet: hex-encoded (0x-prefixed) 65-byte ECDSA
+    /// signature over `credential`. Ignored for method = email.
+    #[serde(default)]
+    pub signature: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq, utoipa::ToSchema)]
@@ -54,4 +59,11 @@ pub struct AuthResponse {
     pub user_id: Uuid,
     pub token: String,
     pub expires_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Serialize, utoipa::ToSchema)]
+pub struct SiweNonceResponse {
+    /// Single-use, expires in 5 minutes. Embed as the `Nonce:` field of the
+    /// SIWE message the wallet signs.
+    pub nonce: String,
 }

--- a/server/src/openapi.rs
+++ b/server/src/openapi.rs
@@ -10,6 +10,7 @@ use utoipa::OpenApi;
     paths(
         crate::routes::health::check,
         crate::routes::auth::login,
+        crate::routes::auth::wallet_nonce,
         crate::routes::auth::refresh,
         crate::routes::account::create,
         crate::routes::account::fetch,
@@ -24,6 +25,7 @@ use utoipa::OpenApi;
             crate::models::user::AuthMethod,
             crate::models::user::RefreshRequest,
             crate::models::user::AuthResponse,
+            crate::models::user::SiweNonceResponse,
             crate::models::account::CreateAccountRequest,
             crate::models::account::AccountResponse,
             crate::models::session::IssueSessionKeyRequest,

--- a/server/src/routes/auth.rs
+++ b/server/src/routes/auth.rs
@@ -4,6 +4,8 @@ use axum::{
     Json,
 };
 use sha2::{Digest, Sha256};
+use siwe::{Message, VerificationOpts};
+use std::str::FromStr;
 use uuid::Uuid;
 
 use crate::{
@@ -11,7 +13,9 @@ use crate::{
     auth_jwt,
     error::{AppError, AppResult},
     middleware::AuthUser,
-    models::user::{AuthResponse, DbUser, LoginRequest, RefreshRequest},
+    models::user::{
+        AuthMethod, AuthResponse, DbUser, LoginRequest, RefreshRequest, SiweNonceResponse,
+    },
     routes::AppState,
 };
 
@@ -45,7 +49,13 @@ pub async fn login(
         return Err(AppError::RateLimited);
     }
 
-    let credential_hash = hash_credential(&body.credential);
+    let credential_hash = match body.method {
+        AuthMethod::Email => hash_credential(&body.credential),
+        AuthMethod::Wallet => {
+            let address = verify_wallet_login(&state, &body).await?;
+            hash_credential(&address)
+        }
+    };
 
     let existing: Option<DbUser> = sqlx::query_as(
         "SELECT id, auth_method, auth_credential_hash, created_at FROM users WHERE auth_credential_hash = ?",
@@ -180,4 +190,110 @@ fn hash_credential(credential: &str) -> String {
     let mut h = Sha256::new();
     h.update(credential.as_bytes());
     format!("{:x}", h.finalize())
+}
+
+/// GET /auth/wallet/nonce — issue a single-use SIWE nonce.
+/// Embed the returned value as the `Nonce:` field of the EIP-4361 message
+/// the wallet signs; it expires in 5 minutes and is consumed on first use.
+#[utoipa::path(
+    get,
+    path = "/auth/wallet/nonce",
+    tag = "auth",
+    responses(
+        (status = 200, description = "Nonce issued", body = crate::models::user::SiweNonceResponse),
+        (status = 429, description = "Rate limited"),
+    )
+)]
+#[tracing::instrument(skip(state, headers))]
+pub async fn wallet_nonce(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+) -> AppResult<Json<SiweNonceResponse>> {
+    let ip = headers
+        .get("x-forwarded-for")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("unknown");
+    if !state.rate_limiter.check(&format!("siwe-nonce:{ip}")) {
+        return Err(AppError::RateLimited);
+    }
+
+    let nonce = siwe::generate_nonce();
+    let expires_at = chrono::Utc::now().timestamp() + 300;
+
+    sqlx::query("INSERT INTO siwe_nonces (nonce, expires_at) VALUES (?, ?)")
+        .bind(&nonce)
+        .bind(expires_at)
+        .execute(&state.db)
+        .await?;
+
+    Ok(Json(SiweNonceResponse { nonce }))
+}
+
+/// Verifies a SIWE (EIP-4361) login: parses `body.credential` as a SIWE
+/// message, checks its nonce was actually issued by this server and hasn't
+/// been used already, checks the domain matches this deployment (phishing/
+/// cross-site relay protection), checks the message is currently valid
+/// (issued_at/expiration/not_before), and recovers the signer from
+/// `body.signature` to confirm it matches the address the message claims.
+///
+/// Returns the lowercased signer address on success — never the raw
+/// signature or any key material.
+async fn verify_wallet_login(state: &AppState, body: &LoginRequest) -> AppResult<String> {
+    let signature_hex = body
+        .signature
+        .as_deref()
+        .ok_or(AppError::BadRequest("missing signature".into()))?;
+
+    let message = Message::from_str(&body.credential)
+        .map_err(|_| AppError::BadRequest("invalid SIWE message".into()))?;
+
+    let enabled_chains: Vec<u64> = state
+        .config
+        .chains
+        .all()
+        .iter()
+        .map(|(_, c)| c.chain_id)
+        .collect();
+    if !enabled_chains.contains(&message.chain_id) {
+        return Err(AppError::BadRequest("unsupported chain".into()));
+    }
+
+    let sig_bytes = hex::decode(signature_hex.trim_start_matches("0x"))
+        .map_err(|_| AppError::BadRequest("invalid signature encoding".into()))?;
+    if sig_bytes.len() != 65 {
+        return Err(AppError::BadRequest("invalid signature length".into()));
+    }
+
+    // Consume the nonce atomically: a DELETE that also checks expiry means
+    // an already-used, never-issued, or expired nonce all fail the same way
+    // (rows_affected == 0), with no separate read-then-write race window.
+    let now = chrono::Utc::now().timestamp();
+    let deleted = sqlx::query("DELETE FROM siwe_nonces WHERE nonce = ? AND expires_at > ?")
+        .bind(&message.nonce)
+        .bind(now)
+        .execute(&state.db)
+        .await?;
+    if deleted.rows_affected() != 1 {
+        return Err(AppError::Unauthorized("invalid or expired nonce"));
+    }
+
+    let domain = state
+        .config
+        .server
+        .siwe_domain
+        .parse()
+        .map_err(|_| AppError::Internal("misconfigured siwe_domain".into()))?;
+
+    let opts = VerificationOpts {
+        domain: Some(domain),
+        nonce: None,     // already verified via the DB-backed single-use check above
+        timestamp: None, // validate against wall-clock now via issued_at/expiration
+    };
+
+    message
+        .verify(&sig_bytes, &opts)
+        .await
+        .map_err(|_| AppError::Unauthorized("invalid signature"))?;
+
+    Ok(format!("0x{}", hex::encode(message.address)).to_lowercase())
 }

--- a/server/src/routes/mod.rs
+++ b/server/src/routes/mod.rs
@@ -78,6 +78,7 @@ pub fn build(db: Db, config: Config) -> Router {
         .route("/api/openapi.json", get(openapi_json))
         .route("/health", get(health::check))
         .route("/auth/login", post(auth::login))
+        .route("/auth/wallet/nonce", get(auth::wallet_nonce))
         .route("/auth/refresh", post(auth::refresh))
         .route("/auth/logout", post(auth::logout))
         .route("/account/create", post(account::create))

--- a/server/tests/helpers.rs
+++ b/server/tests/helpers.rs
@@ -35,6 +35,7 @@ pub async fn test_server_and_db_with_bundler(
             port: 0,
             cors_origins: vec!["http://localhost:3000".to_string()],
             log_format: "pretty".to_string(),
+            siwe_domain: "localhost:3000".to_string(),
         },
         database: DatabaseConfig {
             url: "sqlite::memory:".to_string(),

--- a/server/tests/wallet_login.rs
+++ b/server/tests/wallet_login.rs
@@ -1,0 +1,237 @@
+mod helpers;
+use axum::http::StatusCode;
+use k256::ecdsa::SigningKey;
+use serde_json::json;
+use std::str::FromStr;
+
+/// Deterministic test key — worthless, well-known value, sufficient to
+/// exercise real ECDSA signing + recovery in tests.
+fn test_signing_key() -> SigningKey {
+    SigningKey::from_bytes(&[0x11; 32].into()).unwrap()
+}
+
+/// EIP-55 checksummed address — the `siwe` crate's parser requires this
+/// exact casing on the address line, matching what a real wallet (viem's
+/// `getAddress()`, MetaMask) always produces.
+fn signer_address(key: &SigningKey) -> String {
+    use sha3::{Digest, Keccak256};
+    let point = key.verifying_key().to_encoded_point(false);
+    let hash = Keccak256::digest(&point.as_bytes()[1..]);
+    let addr: [u8; 20] = hash[12..].try_into().unwrap();
+    siwe::eip55(&addr)
+}
+
+/// Signs `message` the way a wallet's `personal_sign` would: EIP-191 prefix
+/// (handled by siwe's `eip191_hash`), recoverable ECDSA, v as 27/28.
+fn sign_siwe(key: &SigningKey, message: &siwe::Message) -> [u8; 65] {
+    let hash = message.eip191_hash().unwrap();
+    let (sig, recid) = key.sign_prehash_recoverable(&hash).unwrap();
+    let mut out = [0u8; 65];
+    out[..64].copy_from_slice(&sig.to_bytes());
+    out[64] = recid.to_byte() + 27;
+    out
+}
+
+async fn get_nonce(server: &axum_test::TestServer) -> String {
+    let res = server.get("/auth/wallet/nonce").await;
+    res.assert_status(StatusCode::OK);
+    res.json::<serde_json::Value>()["nonce"]
+        .as_str()
+        .unwrap()
+        .to_string()
+}
+
+fn build_message(address: &str, nonce: &str) -> siwe::Message {
+    let text = format!(
+        "localhost:3000 wants you to sign in with your Ethereum account:\n{address}\n\nSign in to GhostKey\n\nURI: http://localhost:3000\nVersion: 1\nChain ID: 84532\nNonce: {nonce}\nIssued At: {issued_at}",
+        issued_at = chrono::Utc::now().to_rfc3339(),
+    );
+    siwe::Message::from_str(&text).expect("valid SIWE message")
+}
+
+#[tokio::test]
+async fn wallet_login_new_user_returns_201() {
+    let server = helpers::test_server().await;
+    let key = test_signing_key();
+    let address = signer_address(&key);
+    let nonce = get_nonce(&server).await;
+    let message = build_message(&address, &nonce);
+    let sig = sign_siwe(&key, &message);
+
+    let res = server
+        .post("/auth/login")
+        .json(&json!({
+            "method": "wallet",
+            "credential": message.to_string(),
+            "signature": format!("0x{}", hex::encode(sig)),
+        }))
+        .await;
+
+    res.assert_status(StatusCode::CREATED);
+    let body = res.json::<serde_json::Value>();
+    assert!(body["user_id"].is_string());
+    assert!(body["token"].is_string());
+}
+
+#[tokio::test]
+async fn wallet_login_returning_user_same_id() {
+    let server = helpers::test_server().await;
+    let key = test_signing_key();
+    let address = signer_address(&key);
+
+    let nonce1 = get_nonce(&server).await;
+    let message1 = build_message(&address, &nonce1);
+    let sig1 = sign_siwe(&key, &message1);
+    let r1 = server
+        .post("/auth/login")
+        .json(&json!({
+            "method": "wallet",
+            "credential": message1.to_string(),
+            "signature": format!("0x{}", hex::encode(sig1)),
+        }))
+        .await;
+    r1.assert_status(StatusCode::CREATED);
+
+    let nonce2 = get_nonce(&server).await;
+    let message2 = build_message(&address, &nonce2);
+    let sig2 = sign_siwe(&key, &message2);
+    let r2 = server
+        .post("/auth/login")
+        .json(&json!({
+            "method": "wallet",
+            "credential": message2.to_string(),
+            "signature": format!("0x{}", hex::encode(sig2)),
+        }))
+        .await;
+    r2.assert_status(StatusCode::OK);
+
+    assert_eq!(
+        r1.json::<serde_json::Value>()["user_id"],
+        r2.json::<serde_json::Value>()["user_id"]
+    );
+}
+
+// A signature from a DIFFERENT key than the address claimed in the message
+// must be rejected — this is the actual security property under test.
+#[tokio::test]
+async fn wallet_login_wrong_signer_returns_401() {
+    let server = helpers::test_server().await;
+    let claimed_key = test_signing_key();
+    let claimed_address = signer_address(&claimed_key);
+    let attacker_key = SigningKey::from_bytes(&[0x22; 32].into()).unwrap();
+
+    let nonce = get_nonce(&server).await;
+    let message = build_message(&claimed_address, &nonce);
+    let sig = sign_siwe(&attacker_key, &message); // signed by the wrong key
+
+    let res = server
+        .post("/auth/login")
+        .json(&json!({
+            "method": "wallet",
+            "credential": message.to_string(),
+            "signature": format!("0x{}", hex::encode(sig)),
+        }))
+        .await;
+
+    res.assert_status(StatusCode::UNAUTHORIZED);
+}
+
+// A nonce this server never issued must be rejected.
+#[tokio::test]
+async fn wallet_login_unknown_nonce_returns_401() {
+    let server = helpers::test_server().await;
+    let key = test_signing_key();
+    let address = signer_address(&key);
+
+    let message = build_message(&address, "never-issued-by-server");
+    let sig = sign_siwe(&key, &message);
+
+    let res = server
+        .post("/auth/login")
+        .json(&json!({
+            "method": "wallet",
+            "credential": message.to_string(),
+            "signature": format!("0x{}", hex::encode(sig)),
+        }))
+        .await;
+
+    res.assert_status(StatusCode::UNAUTHORIZED);
+}
+
+// A nonce can't be replayed — second use of the same nonce is rejected.
+#[tokio::test]
+async fn wallet_login_replayed_nonce_returns_401() {
+    let server = helpers::test_server().await;
+    let key = test_signing_key();
+    let address = signer_address(&key);
+    let nonce = get_nonce(&server).await;
+    let message = build_message(&address, &nonce);
+    let sig = sign_siwe(&key, &message);
+
+    let payload = json!({
+        "method": "wallet",
+        "credential": message.to_string(),
+        "signature": format!("0x{}", hex::encode(sig)),
+    });
+
+    let r1 = server.post("/auth/login").json(&payload).await;
+    r1.assert_status(StatusCode::CREATED);
+
+    let r2 = server.post("/auth/login").json(&payload).await;
+    r2.assert_status(StatusCode::UNAUTHORIZED);
+}
+
+// A message signed for a different domain (phishing/relay scenario) is rejected
+// even with a valid nonce and a correctly matching signature.
+#[tokio::test]
+async fn wallet_login_wrong_domain_returns_401() {
+    let server = helpers::test_server().await;
+    let key = test_signing_key();
+    let address = signer_address(&key);
+    let nonce = get_nonce(&server).await;
+
+    let text = format!(
+        "evil-phishing-site.com wants you to sign in with your Ethereum account:\n{address}\n\nSign in\n\nURI: http://evil-phishing-site.com\nVersion: 1\nChain ID: 84532\nNonce: {nonce}\nIssued At: {issued_at}",
+        issued_at = chrono::Utc::now().to_rfc3339(),
+    );
+    let message = siwe::Message::from_str(&text).unwrap();
+    let sig = sign_siwe(&key, &message);
+
+    let res = server
+        .post("/auth/login")
+        .json(&json!({
+            "method": "wallet",
+            "credential": message.to_string(),
+            "signature": format!("0x{}", hex::encode(sig)),
+        }))
+        .await;
+
+    res.assert_status(StatusCode::UNAUTHORIZED);
+}
+
+// No private key or signature material should ever be echoed back.
+#[tokio::test]
+async fn wallet_login_no_signature_in_response() {
+    let server = helpers::test_server().await;
+    let key = test_signing_key();
+    let address = signer_address(&key);
+    let nonce = get_nonce(&server).await;
+    let message = build_message(&address, &nonce);
+    let sig = sign_siwe(&key, &message);
+    let sig_hex = hex::encode(sig);
+
+    let res = server
+        .post("/auth/login")
+        .json(&json!({
+            "method": "wallet",
+            "credential": message.to_string(),
+            "signature": format!("0x{sig_hex}"),
+        }))
+        .await;
+
+    let body = res.text();
+    assert!(
+        !body.contains(&sig_hex),
+        "signature leaked into response: {body}"
+    );
+}


### PR DESCRIPTION
## Summary
`AuthMethod::Wallet` and the SDK's `'wallet' | 'email'` type have existed since Phase 1 but were never actually implemented — `POST /auth/login` just hashed whatever string was sent as `credential` regardless of method, with **zero signature verification** for wallet auth. This implements it for real.

**Server**
- `GET /auth/wallet/nonce` — single-use, 5-min nonce, rate-limited, consumed via an atomic `DELETE ... WHERE expires_at > now` (no `used`-flag race).
- `POST /auth/login` (method=wallet): parses `credential` as a SIWE (EIP-4361) message using the `siwe` crate (spruceid, the spec authors — chosen over hand-rolling parsing for a security-critical field), verifies nonce validity, `domain` match (new `server.siwe_domain` config — phishing/relay guard), time validity, `chain_id` against enabled chains, and recovers the signer to confirm it matches the claimed address.
- New migration `0005_siwe_nonces` (sqlite + postgres).
- New dep `siwe 0.6` — pulls in k256/sha3 only, no ethers. `cargo audit` clean.
- 7 new integration tests on the actual security properties: wrong signer, unknown nonce, replayed nonce, wrong domain all rejected; no signature material leaks into responses.

**SDK**
- `useWalletLogin()` — `window.ethereum` → nonce → build SIWE message → `personal_sign` → existing `useLogin` flow. Composes `useLogin` rather than duplicating state.
- `buildSiweMessage()` / `toPersonalSignHex()` exported — message layout matches the Rust crate's `Display` impl exactly (server re-parses this text).
- Unit tests for the hook and an exact-format test for the message builder.

**Docs**: quickstart, SDK hook reference, API reference, `config.toml.example`. Also fixed a stray corrupted first line in `docs/api/endpoints.md` noticed while editing it.

## Test plan
- [x] `cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo audit` all clean
- [x] Full Rust suite: all existing tests pass unchanged + 7 new wallet-login tests pass
- [x] SDK: `npm run typecheck`, `npm run lint`, `npm run build` all clean
- [x] SDK test suite: 83/83 pass (7 new), coverage 95.3% (above the 80% gate)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)