### PR TITLE
fix(dashboard): backend health check can't reach the server container

### DIFF
--- a/dashboard/docker-compose.yml
+++ b/dashboard/docker-compose.yml
@@ -28,6 +28,15 @@ services:
       # Falls back to your local `gh` auth if you export it yourself, e.g.:
       #   GITHUB_TOKEN=$(gh auth token) docker compose -f dashboard/docker-compose.yml up
       - GITHUB_TOKEN=${GITHUB_TOKEN:-}
+      # Points the "Backend/Health" panel at the real server's container
+      # (name: ghostkey above matches the root docker-compose.yml's project
+      # name, so both land on the same `ghostkey_default` network and can
+      # reach each other by container name — no explicit network/depends_on
+      # needed). 127.0.0.1 would only ever mean this container itself.
+      # Harmless if `server` isn't running — the healthcheck just reports
+      # down, same as today.
+      - BACKEND_HOST=ghostkey-server
+      - BACKEND_PORT=8080
     restart: unless-stopped
 
 volumes:

--- a/dashboard/server.js
+++ b/dashboard/server.js
@@ -291,11 +291,17 @@ app.get('/api/github/releases', (req, res) => ghFetch('/releases?per_page=20', r
 
 // ── Backend health-check proxy ────────────────────────────────────────────────
 app.get('/api/healthcheck', async (req, res) => {
+  // Host defaults to 127.0.0.1 for local `npm run dev` (server runs on the
+  // same machine). In the dashboard's own container, 127.0.0.1 only ever
+  // means the dashboard container itself — the real server is a sibling
+  // container reachable by its Compose service name instead, so this needs
+  // to be overridable (set via BACKEND_HOST in dashboard/docker-compose.yml).
+  const host = process.env.BACKEND_HOST || '127.0.0.1'
   const port = process.env.BACKEND_PORT || 3001
   try {
     const controller = new AbortController()
     const tid = setTimeout(() => controller.abort(), 3000)
-    const r = await fetch(`http://127.0.0.1:${port}/health`, { signal: controller.signal })
+    const r = await fetch(`http://${host}:${port}/health`, { signal: controller.signal })
     clearTimeout(tid)
     const data = await r.json()
     res.json({ ok: r.ok, status: r.status, data })


### PR DESCRIPTION
## Summary
Found live: Docker Desktop showed `ghostkey-server` running and healthy, but the dashboard's Backend/Health panel still said DOWN.

Root cause: `/api/healthcheck` hardcoded `127.0.0.1` — correct for local `npm run dev` (server on the same machine), wrong inside the dashboard's own container, where `127.0.0.1` only ever means itself. The real server is a sibling container on the same `ghostkey_default` network (both compose files share `name: ghostkey`), reachable by container name — but only `BACKEND_PORT` was overridable, not the host.

- `dashboard/server.js`: reads `BACKEND_HOST` now (defaults to `127.0.0.1`, local dev unchanged)
- `dashboard/docker-compose.yml`: sets `BACKEND_HOST=ghostkey-server`, `BACKEND_PORT=8080`

## Test plan
- [x] `node --check server.js`
- [x] Verified live against the actually-running containers (not just code review) — see below
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)