### PR TITLE
chore: promote dev → main

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -534,7 +534,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -813,9 +813,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",

--- a/dashboard/docker-compose.yml
+++ b/dashboard/docker-compose.yml
@@ -9,6 +9,8 @@ services:
   dashboard:
     build: .
     container_name: ghostkey-dashboard
+    mem_limit: 768m
+    cpus: "0.75"
     working_dir: /repo/dashboard
     ports:
       - "3002:3002" # frontend (React + Vite)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,8 @@ services:
   server:
     build: .
     container_name: ghostkey-server
+    mem_limit: 512m
+    cpus: "0.50"
     ports:
       - "8080:8080"
     volumes:
@@ -41,6 +43,8 @@ services:
       context: .
       dockerfile: example/Dockerfile
     container_name: ghostkey-example
+    mem_limit: 512m
+    cpus: "0.50"
     depends_on:
       - server
     ports:

--- a/story/docker-compose.yml
+++ b/story/docker-compose.yml
@@ -7,6 +7,8 @@ services:
   story:
     build: .
     container_name: ghostkey-story
+    mem_limit: 512m
+    cpus: "0.50"
     ports:
       - "3005:3005"
     restart: unless-stopped


### PR DESCRIPTION
## Summary
- Promotes `dev` → `main`.
- Includes: memory/CPU limits added to all four `ghostkey-*` containers (server, example, dashboard, story), plus an `h2` bump to 0.4.16 to clear RUSTSEC-2026-0258.

## Test plan
- [x] CI green on dev (Rust, SDK, Security all pass)